### PR TITLE
feat: report details page

### DIFF
--- a/app/api/report/[id]/route.ts
+++ b/app/api/report/[id]/route.ts
@@ -1,0 +1,40 @@
+import path from 'node:path';
+
+import { type NextRequest } from 'next/server';
+
+import { readFile } from '@/app/lib/data';
+import { parse } from '@/app/lib/parser';
+import { withError } from '@/app/lib/withError';
+
+export const dynamic = 'force-dynamic'; // defaults to auto
+
+export async function GET(
+  req: NextRequest,
+  {
+    params,
+  }: {
+    params: {
+      id: string;
+    };
+  },
+) {
+  const { id } = params;
+
+  if (!id) {
+    return new Response('report ID is required', { status: 400 });
+  }
+
+  const { result: html, error } = await withError(readFile(path.join(id, 'index.html'), 'text/html'));
+
+  if (error || !html) {
+    return new Response(`failed to read report html file: ${error?.message ?? 'unknown error'}`, { status: 404 });
+  }
+
+  const { result: info, error: parseError } = await withError(parse(html as string));
+
+  if (parseError || !info) {
+    return new Response(`failed to parse report html file: ${parseError?.message ?? 'unknown error'}`, { status: 400 });
+  }
+
+  return Response.json(info);
+}

--- a/app/components/report-details/file-list.tsx
+++ b/app/components/report-details/file-list.tsx
@@ -1,0 +1,40 @@
+'use client';
+
+import React from 'react';
+import { Accordion, AccordionItem } from '@nextui-org/react';
+
+import { subtitle } from '../primitives';
+import { StatChart } from '../stat-chart';
+
+import renderFileSuitesTree from './suite-tree';
+
+import { ReportInfo } from '@/app/lib/parser';
+import { ReportHistory } from '@/app/lib/data';
+
+interface FileListProps {
+  report?: ReportInfo | null;
+  history: ReportHistory[];
+}
+
+const FileList: React.FC<FileListProps> = ({ report, history }) => {
+  return (
+    <div>
+      <h2 className={subtitle()}>File list</h2>
+      <Accordion variant="bordered">
+        {(report?.files ?? []).map((file) => (
+          <AccordionItem key={file.fileId} aria-label={file.fileName} title={file.fileName}>
+            <div className="file-details">
+              <StatChart stats={file.stats} />
+              <div className="file-tests">
+                <h4 className={subtitle()}>Tests</h4>
+                {renderFileSuitesTree(file, history)}
+              </div>
+            </div>
+          </AccordionItem>
+        ))}
+      </Accordion>
+    </div>
+  );
+};
+
+export default FileList;

--- a/app/components/report-details/file-list.tsx
+++ b/app/components/report-details/file-list.tsx
@@ -8,11 +8,10 @@ import { StatChart } from '../stat-chart';
 
 import renderFileSuitesTree from './suite-tree';
 
-import { ReportInfo } from '@/app/lib/parser';
 import { ReportHistory } from '@/app/lib/data';
 
 interface FileListProps {
-  report?: ReportInfo | null;
+  report?: ReportHistory | null;
   history: ReportHistory[];
 }
 

--- a/app/components/report-details/report-stats.tsx
+++ b/app/components/report-details/report-stats.tsx
@@ -1,0 +1,26 @@
+'use client';
+
+import React from 'react';
+
+import { StatChart } from '../stat-chart';
+
+import { type ReportStats } from '@/app/lib/parser';
+
+interface StatisticsProps {
+  stats?: ReportStats;
+}
+
+const ReportStatistics: React.FC<StatisticsProps> = ({ stats }) => {
+  if (!stats || Object.keys(stats).length === 0) {
+    return <div>No statistics available</div>;
+  }
+
+  return (
+    <div className="min-w-[400px] min-h-max">
+      <h2 className="text-center">Total: {stats.total} tests</h2>
+      <StatChart stats={stats} />
+    </div>
+  );
+};
+
+export default ReportStatistics;

--- a/app/components/report-details/suite-tree.tsx
+++ b/app/components/report-details/suite-tree.tsx
@@ -1,0 +1,95 @@
+'use client';
+
+import React from 'react';
+import { Accordion, AccordionItem, Chip } from '@nextui-org/react';
+
+import TestInfo from './test-info';
+
+import { ReportFile, ReportTest } from '@/app/lib/parser';
+import { ReportHistory } from '@/app/lib/data';
+
+interface SuiteNode {
+  name: string;
+  children: SuiteNode[];
+  tests: ReportTest[];
+}
+
+function buildTestTree(rootName: string, tests: ReportTest[]): SuiteNode {
+  const root: SuiteNode = { name: rootName, children: [], tests: [] };
+
+  tests.forEach((test) => {
+    const { path } = test;
+
+    const noSuites = path.length === 0;
+
+    if (noSuites) {
+      root.tests.push(test);
+
+      return;
+    }
+
+    const lastNodeIndex = path.length - 1;
+
+    path.reduce((currentNode, suiteName, index) => {
+      const existingSuite = currentNode.children.find((child) => child.name === suiteName);
+
+      const noMoreSuites = index === lastNodeIndex;
+
+      if (noMoreSuites && existingSuite) {
+        existingSuite.tests.push(test);
+      }
+
+      if (existingSuite) {
+        return existingSuite;
+      }
+
+      const newSuite: SuiteNode = { name: suiteName, children: [], tests: [] };
+
+      currentNode.children.push(newSuite);
+
+      if (noMoreSuites) {
+        newSuite.tests.push(test);
+      }
+
+      return newSuite;
+    }, root);
+  });
+
+  return root;
+}
+
+const renderSuiteNode = (suite: SuiteNode, history: ReportHistory[]) => {
+  return (
+    <Accordion key={suite.name} aria-label={suite.name} selectionMode="multiple" title={suite.name}>
+      {[
+        ...suite.children.map((child) => (
+          <AccordionItem key={child.name} aria-label={child.name} className="p-2" title={`${child.name}`}>
+            {renderSuiteNode(child, history)}
+          </AccordionItem>
+        )),
+        ...suite.tests.map((test) => (
+          <AccordionItem
+            key={test.testId}
+            aria-label={test.title}
+            className="p-2"
+            title={
+              <span className="flex flex-row gap-4 flex-wrap">
+                {`· ${test.title}`}
+                <Chip color="default" size="sm">
+                  {test.projectName}
+                </Chip>
+              </span>
+            }
+          >
+            <TestInfo history={history} test={test} />
+          </AccordionItem>
+        )),
+      ]}
+    </Accordion>
+  );
+};
+
+const renderFileSuitesTree = (file: ReportFile, history: ReportHistory[]) =>
+  renderSuiteNode(buildTestTree(file.fileName, file.tests), history);
+
+export default renderFileSuitesTree;

--- a/app/components/report-details/suite-tree.tsx
+++ b/app/components/report-details/suite-tree.tsx
@@ -7,6 +7,7 @@ import TestInfo from './test-info';
 
 import { ReportFile, ReportTest } from '@/app/lib/parser';
 import { ReportHistory } from '@/app/lib/data';
+import { testStatusToColor } from '@/app/lib/tailwind';
 
 interface SuiteNode {
   name: string;
@@ -67,23 +68,30 @@ const renderSuiteNode = (suite: SuiteNode, history: ReportHistory[]) => {
             {renderSuiteNode(child, history)}
           </AccordionItem>
         )),
-        ...suite.tests.map((test) => (
-          <AccordionItem
-            key={test.testId}
-            aria-label={test.title}
-            className="p-2"
-            title={
-              <span className="flex flex-row gap-4 flex-wrap">
-                {`· ${test.title}`}
-                <Chip color="default" size="sm">
-                  {test.projectName}
-                </Chip>
-              </span>
-            }
-          >
-            <TestInfo history={history} test={test} />
-          </AccordionItem>
-        )),
+        ...suite.tests.map((test) => {
+          const status = testStatusToColor(test.outcome);
+
+          return (
+            <AccordionItem
+              key={test.testId}
+              aria-label={test.title}
+              className="p-2"
+              title={
+                <span className="flex flex-row gap-4 flex-wrap">
+                  {`· ${test.title}`}
+                  <Chip color={status.colorName} size="sm">
+                    {status.title}
+                  </Chip>
+                  <Chip color="default" size="sm">
+                    {test.projectName}
+                  </Chip>
+                </span>
+              }
+            >
+              <TestInfo history={history} test={test} />
+            </AccordionItem>
+          );
+        }),
       ]}
     </Accordion>
   );

--- a/app/components/report-details/test-info.tsx
+++ b/app/components/report-details/test-info.tsx
@@ -1,0 +1,95 @@
+'use client';
+
+import React from 'react';
+import { Link, LinkIcon, Table, TableBody, TableCell, TableColumn, TableHeader, TableRow } from '@nextui-org/react';
+
+import FormattedDate from '../date-format';
+
+import { subtitle } from '@/app/components/primitives';
+import { parseMilliseconds } from '@/app/lib/time';
+import { TestHistory, type ReportHistory } from '@/app/lib/data';
+import { type ReportTest } from '@/app/lib/parser/types';
+import { testStatusToColor } from '@/app/lib/tailwind';
+
+interface TestInfoProps {
+  history: ReportHistory[];
+  test: ReportTest;
+}
+
+const getTestHistory = (testId: string, history: ReportHistory[]) => {
+  return history
+    .map((report) => {
+      const file = report.files.find((file) => file.tests.some((test) => test.testId === testId));
+
+      if (!file) {
+        return;
+      }
+
+      const test = file.tests.find((test) => test.testId === testId);
+
+      if (!test) {
+        return;
+      }
+
+      return {
+        ...test,
+        createdAt: report.createdAt,
+        reportID: report.reportID,
+        reportUrl: report.reportUrl,
+      };
+    })
+    .filter(Boolean) as unknown as TestHistory[];
+};
+
+const TestInfo: React.FC<TestInfoProps> = ({ test, history }: TestInfoProps) => {
+  const formatted = testStatusToColor(test.outcome);
+
+  return (
+    <div className=" shadow-md rounded-lg p-6">
+      <div className="mb-4">
+        <p>
+          Outcome: <span className={formatted.color}>{formatted.title}</span>
+        </p>
+        <p>Location: {`${test.location.file}:${test.location.line}:${test.location.column}`}</p>
+        <p>Duration: {parseMilliseconds(test.duration)}</p>
+        {test.annotations.length > 0 && <p>Annotations: {test.annotations.map((a) => JSON.stringify(a)).join(', ')}</p>}
+        {test.tags.length > 0 && <p>Tags: {test.tags.join(', ')}</p>}
+      </div>
+      <div>
+        <h3 className={subtitle()}>Results:</h3>
+        <Table aria-label="Test History">
+          <TableHeader>
+            <TableColumn>Created At</TableColumn>
+            <TableColumn>Status</TableColumn>
+            <TableColumn>Duration</TableColumn>
+            <TableColumn>Actions</TableColumn>
+          </TableHeader>
+          <TableBody items={getTestHistory(test.testId, history)}>
+            {(item) => {
+              const itemOutcome = testStatusToColor(item?.outcome);
+
+              return (
+                <TableRow key={`${item.reportID}-${item.testId}`}>
+                  <TableCell className="w-3/8">
+                    <FormattedDate date={item?.createdAt} />
+                  </TableCell>
+                  <TableCell className="w-2/8">
+                    <span className={itemOutcome.color}>{itemOutcome.title}</span>
+                  </TableCell>
+                  <TableCell className="w-2/8">{parseMilliseconds(item.duration)}</TableCell>
+                  <TableCell className="w-1/8">
+                    <Link href={`${item.reportUrl}#?testId=${item.testId}`} target="_blank">
+                      <LinkIcon />
+                    </Link>
+                  </TableCell>
+                </TableRow>
+              );
+            }}
+          </TableBody>
+        </Table>
+      </div>
+    </div>
+  );
+};
+
+export default TestInfo;

--- a/app/components/report-trends.tsx
+++ b/app/components/report-trends.tsx
@@ -6,11 +6,10 @@ import { TrendChart } from '@/app/components/trend-chart';
 import { title } from '@/app/components/primitives';
 import useQuery from '@/app/hooks/useQuery';
 import ErrorMessage from '@/app/components/error-message';
-import { type Report } from '@/app/lib/data';
-import { type ReportInfo } from '@/app/lib/parser';
+import { type ReportHistory } from '@/app/lib/data';
 
 export default function ReportTrends() {
-  const { data: reports, error, isLoading } = useQuery<(Report & ReportInfo)[]>('/api/report/trend');
+  const { data: reports, error, isLoading } = useQuery<ReportHistory[]>('/api/report/trend');
 
   return (
     <>

--- a/app/components/reports-table.tsx
+++ b/app/components/reports-table.tsx
@@ -11,6 +11,7 @@ import {
   Tooltip,
   Button,
   Pagination,
+  LinkIcon,
 } from '@nextui-org/react';
 import Link from 'next/link';
 
@@ -104,7 +105,13 @@ export default function ReportsTable({ onChange }: ReportsTableProps) {
       <TableBody emptyContent="No reports." isLoading={isLoading} items={viewReports ?? []}>
         {(item) => (
           <TableRow key={item.reportID}>
-            <TableCell className="w-1/2">{item.reportID}</TableCell>
+            <TableCell className="w-1/2">
+              <Link href={`/report/${item.reportID}`}>
+                <div className="flex flex-row">
+                  {item.reportID} <LinkIcon />
+                </div>
+              </Link>
+            </TableCell>
             <TableCell className="w-1/4">
               <FormattedDate date={item.createdAt} />
             </TableCell>

--- a/app/components/stat-chart.tsx
+++ b/app/components/stat-chart.tsx
@@ -1,0 +1,85 @@
+'use client';
+import * as React from 'react';
+import { Label, Pie, PieChart } from 'recharts';
+
+import { type ChartConfig, ChartContainer, ChartTooltip, ChartTooltipContent } from '@/app/components/ui/chart';
+
+const chartConfig = {
+  count: {
+    label: 'Count',
+  },
+  expected: {
+    label: 'Passed',
+    color: 'hsl(var(--chart-1))',
+  },
+  unexpected: {
+    label: 'Failed',
+    color: 'hsl(var(--chart-2))',
+  },
+  flaky: {
+    label: 'Flaky',
+    color: 'hsl(var(--chart-3))',
+  },
+  skipped: {
+    label: 'Skipped',
+    color: 'hsl(var(--chart-4))',
+  },
+} satisfies ChartConfig;
+
+interface StatChartProps {
+  stats: {
+    total: number;
+    expected: number;
+    unexpected: number;
+    flaky: number;
+    skipped: number;
+    ok: boolean;
+  };
+}
+
+export function StatChart({ stats }: Readonly<StatChartProps>) {
+  const chartData = [
+    {
+      count: stats.expected,
+      status: 'Passed',
+      fill: 'hsl(var(--chart-1))',
+    },
+    {
+      count: stats.unexpected,
+      status: 'Failed',
+      fill: 'hsl(var(--chart-2))',
+    },
+    { count: stats.flaky, status: 'Flaky', fill: 'hsl(var(--chart-4))' },
+    {
+      count: stats.skipped,
+      status: 'Skipped',
+      fill: 'hsl(var(--chart-3))',
+    },
+  ];
+
+  return (
+    <ChartContainer className="mx-auto aspect-square max-h-[250px]" config={chartConfig}>
+      <PieChart>
+        <ChartTooltip content={<ChartTooltipContent hideLabel />} cursor={false} />
+        <Pie data={chartData} dataKey="count" innerRadius={60} nameKey="status" strokeWidth={5}>
+          <Label
+            content={({ viewBox }) => {
+              if (viewBox && 'cx' in viewBox && 'cy' in viewBox) {
+                return (
+                  <text dominantBaseline="middle" textAnchor="middle" x={viewBox.cx} y={viewBox.cy}>
+                    <tspan className="fill-foreground text-3xl font-bold" x={viewBox.cx} y={viewBox.cy}>
+                      {`${Math.round((stats.expected / (stats.total - stats.skipped)) * 100)}%`}
+                    </tspan>
+                    <tspan className="fill-foreground" x={viewBox.cx} y={(viewBox.cy ?? 0) + 24}>
+                      Passed
+                    </tspan>
+                  </text>
+                );
+              }
+            }}
+          />
+        </Pie>
+      </PieChart>
+    </ChartContainer>
+  );
+}

--- a/app/components/trend-chart.tsx
+++ b/app/components/trend-chart.tsx
@@ -2,8 +2,7 @@
 import { Area, AreaChart, XAxis } from 'recharts';
 import Link from 'next/link';
 
-import { type Report } from '@/app/lib/data';
-import { type ReportInfo } from '@/app/lib/parser';
+import { type ReportHistory } from '@/app/lib/data';
 import {
   type ChartConfig,
   ChartContainer,
@@ -32,17 +31,15 @@ const chartConfig = {
   },
 } satisfies ChartConfig;
 
-type TrendReport = Report & ReportInfo;
-
 interface WithTotal {
   total: number;
 }
 
 interface TrendChartProps {
-  reports: TrendReport[];
+  reports: ReportHistory[];
 }
 
-export function TrendChart({ reports }: TrendChartProps) {
+export function TrendChart({ reports }: Readonly<TrendChartProps>) {
   const getPercentage = (value: number, total: number) => Math.round((value / total) * 100);
 
   const openInNewTab = (url: string) => {

--- a/app/components/trend-chart.tsx
+++ b/app/components/trend-chart.tsx
@@ -40,7 +40,7 @@ interface TrendChartProps {
 }
 
 export function TrendChart({ reports }: Readonly<TrendChartProps>) {
-  const getPercentage = (value: number, total: number) => Math.round((value / total) * 100);
+  const getPercentage = (value: number, total: number) => (value / total) * 100;
 
   const openInNewTab = (url: string) => {
     typeof window !== 'undefined' && window.open(url, '_blank', 'noopener,noreferrer');
@@ -112,7 +112,7 @@ export function TrendChart({ reports }: Readonly<TrendChartProps>) {
                         `${name}Count`
                       ]
                     }{' '}
-                    ({value}%)
+                    ({Math.round(value as number)}%)
                   </div>
                   {/* Add this after the last item */}
                   {index === 3 && (

--- a/app/components/verify-auth.tsx
+++ b/app/components/verify-auth.tsx
@@ -1,13 +1,12 @@
 'use client';
 
 import { useRouter, useSearchParams } from 'next/navigation';
-import { setCookie } from 'cookies-next';
 import { Spinner } from '@nextui-org/react';
 import { useEffect } from 'react';
 
 import { title } from '@/app/components/primitives';
 import { useApiToken } from '@/app/providers/ApiTokenProvider';
-import { reportAuthCookieName, serveReportRoute } from '@/app/lib/constants';
+import { setReportAuthCookie } from '@/app/config/cookie';
 
 export default function VerifyAuth() {
   const searchParams = useSearchParams();
@@ -19,14 +18,7 @@ export default function VerifyAuth() {
       const url = searchParams.get('callbackUrl') ?? '';
 
       if (url && apiToken) {
-        const cookieAgeSeconds = 10 * 60; // 10 minutes
-
-        setCookie(reportAuthCookieName, apiToken, {
-          maxAge: cookieAgeSeconds,
-          path: serveReportRoute,
-          secure: true,
-          sameSite: 'strict',
-        });
+        setReportAuthCookie(apiToken);
         router.replace(url);
       }
     }

--- a/app/config/cookie.ts
+++ b/app/config/cookie.ts
@@ -1,0 +1,18 @@
+import { setCookie } from 'cookies-next';
+
+import { reportAuthCookieName, serveReportRoute } from '@/app/lib/constants';
+
+export const setReportAuthCookie = (apiToken: string) => {
+  if (!apiToken) {
+    return;
+  }
+
+  const cookieAgeSeconds = 10 * 60; // 10 minutes
+
+  setCookie(reportAuthCookieName, apiToken, {
+    maxAge: cookieAgeSeconds,
+    path: serveReportRoute,
+    secure: true,
+    sameSite: 'strict',
+  });
+};

--- a/app/lib/data.ts
+++ b/app/lib/data.ts
@@ -7,6 +7,7 @@ import util from 'node:util';
 import getFolderSize from 'get-folder-size';
 
 import { serveReportRoute } from '@/app/lib/constants';
+import { type ReportInfo, type ReportTest } from '@/app/lib/parser';
 
 const execAsync = util.promisify(exec);
 
@@ -18,6 +19,10 @@ export type Result = {
 };
 
 export type Report = { reportID: string; reportUrl: string; createdAt: Date };
+
+export type ReportHistory = Report & ReportInfo;
+
+export type TestHistory = Report & ReportTest;
 
 const DATA_FOLDER = path.join(process.cwd(), 'data');
 const PW_CONFIG = path.join(process.cwd(), 'playwright.config.ts');

--- a/app/lib/parser/types.ts
+++ b/app/lib/parser/types.ts
@@ -11,7 +11,7 @@ interface ReportMetadata {
   actualWorkers: number;
 }
 
-interface ReportStats {
+export interface ReportStats {
   total: number;
   expected: number;
   unexpected: number;
@@ -20,21 +20,21 @@ interface ReportStats {
   ok: boolean;
 }
 
-enum ReportTestOutcome {
+export enum ReportTestOutcome {
   Expected = 'expected',
   Unexpected = 'unexpected',
   Flaky = 'flaky',
   Skipped = 'skipped',
 }
 
-interface ReportFile {
+export interface ReportFile {
   fileId: string;
   fileName: string;
   tests: ReportTest[];
   stats: ReportStats;
 }
 
-interface ReportTest {
+export interface ReportTest {
   testId: string;
   title: string;
   projectName: string;
@@ -46,6 +46,7 @@ interface ReportTest {
   path: string[];
   ok: boolean;
   results: ReportTestResult[];
+  createdAt?: Date;
 }
 
 interface ReportTestLocation {

--- a/app/lib/tailwind.ts
+++ b/app/lib/tailwind.ts
@@ -7,26 +7,43 @@ export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
 
-export function testStatusToColor(outcome?: ReportTestOutcome) {
+enum OutcomeColors {
+  Success = 'success',
+  Primary = 'primary',
+  Danger = 'danger',
+  Warning = 'warning',
+  Default = 'default',
+}
+
+export function testStatusToColor(outcome?: ReportTestOutcome): {
+  title: string;
+  colorName: OutcomeColors;
+  color: string;
+} {
   const outcomes = {
     [ReportTestOutcome.Expected]: {
       title: 'Passed',
+      colorName: OutcomeColors.Success,
       color: 'text-success-500',
     },
     [ReportTestOutcome.Unexpected]: {
       title: 'Failed',
+      colorName: OutcomeColors.Danger,
       color: 'text-danger-500',
     },
     [ReportTestOutcome.Flaky]: {
       title: 'Flaky',
+      colorName: OutcomeColors.Warning,
       color: 'text-warning-500',
     },
     [ReportTestOutcome.Skipped]: {
       title: 'Skipped',
+      colorName: OutcomeColors.Default,
       color: 'text-gray-500',
     },
     unknown: {
       title: 'N/A',
+      colorName: OutcomeColors.Primary,
       color: 'text-gray-200',
     },
   };

--- a/app/lib/tailwind.ts
+++ b/app/lib/tailwind.ts
@@ -1,6 +1,35 @@
 import { type ClassValue, clsx } from 'clsx';
 import { twMerge } from 'tailwind-merge';
 
+import { ReportTestOutcome } from './parser';
+
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
+}
+
+export function testStatusToColor(outcome?: ReportTestOutcome) {
+  const outcomes = {
+    [ReportTestOutcome.Expected]: {
+      title: 'Passed',
+      color: 'text-success-500',
+    },
+    [ReportTestOutcome.Unexpected]: {
+      title: 'Failed',
+      color: 'text-danger-500',
+    },
+    [ReportTestOutcome.Flaky]: {
+      title: 'Flaky',
+      color: 'text-warning-500',
+    },
+    [ReportTestOutcome.Skipped]: {
+      title: 'Skipped',
+      color: 'text-gray-500',
+    },
+    unknown: {
+      title: 'N/A',
+      color: 'text-gray-200',
+    },
+  };
+
+  return outcome ? outcomes[outcome] : outcomes.unknown;
 }

--- a/app/lib/time.ts
+++ b/app/lib/time.ts
@@ -1,0 +1,20 @@
+export const parseMilliseconds = (ms: number) => {
+  const seconds = Math.floor(ms / 1000);
+  const leftMs = ms % 1000;
+  const minutes = Math.floor(seconds / 60);
+  const hours = Math.floor(minutes / 60);
+
+  if (hours > 0) {
+    return `${hours}h ${minutes % 60}m ${seconds % 60}s ${leftMs}ms`;
+  }
+
+  if (minutes > 0) {
+    return `${minutes}m ${seconds % 60}s ${leftMs}ms`;
+  }
+
+  if (seconds > 0) {
+    return `${seconds}s ${leftMs}ms`;
+  }
+
+  return `${leftMs}ms`;
+};

--- a/app/report/[id]/page.tsx
+++ b/app/report/[id]/page.tsx
@@ -1,0 +1,83 @@
+'use client';
+
+import { Spinner, Button } from '@nextui-org/react';
+import Link from 'next/link';
+
+import ReportStatistics from '@/app/components/report-details/report-stats';
+import FileList from '@/app/components/report-details/file-list';
+import useQuery from '@/app/hooks/useQuery';
+import { type ReportInfo } from '@/app/lib/parser';
+import { type ReportHistory } from '@/app/lib/data';
+import { serveReportRoute } from '@/app/lib/constants';
+import { title } from '@/app/components/primitives';
+import { useApiToken } from '@/app/providers/ApiTokenProvider';
+import { setReportAuthCookie } from '@/app/config/cookie';
+
+interface ReportDetailProps {
+  params: { id: string };
+}
+
+function ReportDetail({ params }: Readonly<ReportDetailProps>) {
+  const {
+    data: report,
+    isLoading: isReportLoading,
+    error: reportError,
+  } = useQuery<ReportInfo>(`/api/report/${params.id}`);
+
+  const {
+    data: history,
+    isLoading: isHistoryLoading,
+    error: historyError,
+  } = useQuery<ReportHistory[]>('/api/report/trend?limit=10');
+
+  const { apiToken } = useApiToken();
+
+  // ensure the report is authenticated when specific test history is opened
+  // otherwise report index page will be loaded
+  setReportAuthCookie(apiToken);
+
+  if (!report && isReportLoading) {
+    return (
+      <div>
+        Loading report... <Spinner />
+      </div>
+    );
+  }
+
+  if (isHistoryLoading) {
+    return (
+      <div>
+        Loading test history... <Spinner />
+      </div>
+    );
+  }
+
+  const error = reportError || historyError;
+
+  if (error) {
+    return <p>Error: {error.message}</p>;
+  }
+
+  return (
+    <>
+      <div className="text-center">
+        <h1 className={title()}>Report</h1>
+      </div>
+      <div className="flex md:flex-row flex-col gap-2">
+        <div className="flex flex-col items-center md:w-1/4 max-w-full">
+          <ReportStatistics stats={report?.stats} />
+          <Link href={`${serveReportRoute}/${params.id}/index.html`} target="_blank">
+            <Button as="a" color="primary">
+              Open report
+            </Button>
+          </Link>
+        </div>
+        <div className="md:w-3/4 max-w-full">
+          <FileList history={history ?? []} report={report} />
+        </div>
+      </div>
+    </>
+  );
+}
+
+export default ReportDetail;

--- a/app/report/[id]/page.tsx
+++ b/app/report/[id]/page.tsx
@@ -6,12 +6,12 @@ import Link from 'next/link';
 import ReportStatistics from '@/app/components/report-details/report-stats';
 import FileList from '@/app/components/report-details/file-list';
 import useQuery from '@/app/hooks/useQuery';
-import { type ReportInfo } from '@/app/lib/parser';
 import { type ReportHistory } from '@/app/lib/data';
 import { serveReportRoute } from '@/app/lib/constants';
-import { title } from '@/app/components/primitives';
+import { subtitle, title } from '@/app/components/primitives';
 import { useApiToken } from '@/app/providers/ApiTokenProvider';
 import { setReportAuthCookie } from '@/app/config/cookie';
+import FormattedDate from '@/app/components/date-format';
 
 interface ReportDetailProps {
   params: { id: string };
@@ -22,7 +22,7 @@ function ReportDetail({ params }: Readonly<ReportDetailProps>) {
     data: report,
     isLoading: isReportLoading,
     error: reportError,
-  } = useQuery<ReportInfo>(`/api/report/${params.id}`);
+  } = useQuery<ReportHistory>(`/api/report/${params.id}`);
 
   const {
     data: history,
@@ -62,6 +62,11 @@ function ReportDetail({ params }: Readonly<ReportDetailProps>) {
     <>
       <div className="text-center">
         <h1 className={title()}>Report</h1>
+        {report?.createdAt && (
+          <span className={subtitle()}>
+            <FormattedDate date={report.createdAt} />
+          </span>
+        )}
       </div>
       <div className="flex md:flex-row flex-col gap-2">
         <div className="flex flex-col items-center md:w-1/4 max-w-full">


### PR DESCRIPTION
## Demo

Link: https://cyborg.shelex.dev
Api Token: 12345

Just click on report id and details page will be opened.

## Added
- endpoint for fetching specific report and parse run details
- page for specific report details
- dohnut charts for report and each test file statistics
- tree structure of suites and tests + list of latest results with links to previous reports

## Fixed
- sometimes reports graph was not plain, caused by rounding percentages and sometimes getting >100%. Moved rounding to display values and now it should look better.