### PR TITLE
Feat/add report projects

### DIFF
--- a/app/api/project/list/route.ts
+++ b/app/api/project/list/route.ts
@@ -1,0 +1,14 @@
+import { storage } from '@/app/lib/storage';
+import { withError } from '@/app/lib/withError';
+
+export const dynamic = 'force-dynamic'; // defaults to auto
+
+export async function GET() {
+  const { result: projects, error } = await withError(storage.getProjects());
+
+  if (error) {
+    return new Response(error.message, { status: 400 });
+  }
+
+  return Response.json(projects);
+}

--- a/app/api/report/generate/route.ts
+++ b/app/api/report/generate/route.ts
@@ -5,11 +5,13 @@ export const dynamic = 'force-dynamic'; // defaults to auto
 export async function POST(request: Request) {
   const { result: reqBody, error: reqError } = await withError(request.json());
 
+  const { resultsIds, project } = reqBody;
+
   if (reqError) {
     return new Response(reqError.message, { status: 400 });
   }
 
-  const { result: reportId, error } = await withError(storage.generateReport(reqBody.resultsIds));
+  const { result: reportId, error } = await withError(storage.generateReport(resultsIds, project));
 
   if (error) {
     return new Response(error.message, { status: 404 });
@@ -17,6 +19,7 @@ export async function POST(request: Request) {
 
   return Response.json({
     reportId,
-    reportUrl: `/data/reports/${reportId}/index.html`,
+    project,
+    reportUrl: `/data/reports/${project ? encodeURIComponent(project) : ''}/${reportId}/index.html`,
   });
 }

--- a/app/api/report/trend/route.ts
+++ b/app/api/report/trend/route.ts
@@ -13,7 +13,7 @@ export async function GET() {
 
   const latestReportsInfo = await Promise.all(
     latestReports.map(async (report) => {
-      const html = await storage.readFile(path.join(report.reportID, 'index.html'), 'text/html');
+      const html = await storage.readFile(path.join(report.project ?? '', report.reportID, 'index.html'), 'text/html');
       const info = await parse(html as string);
 
       return {

--- a/app/api/serve/[[...filePath]]/route.ts
+++ b/app/api/serve/[[...filePath]]/route.ts
@@ -1,7 +1,7 @@
 import path from 'path';
 
 import mime from 'mime';
-import { type NextRequest, NextResponse } from 'next/server';
+import { NextRequest, NextResponse } from 'next/server';
 
 import { withError } from '@/app/lib/withError';
 import { storage } from '@/app/lib/storage';
@@ -19,11 +19,9 @@ export async function GET(
     params: ReportParams;
   },
 ) {
-  const { reportId, filePath } = params;
+  const { filePath } = params;
 
-  const file = Array.isArray(filePath) ? filePath.join('/') : (filePath ?? '');
-
-  const targetPath = path.join(reportId, file);
+  const targetPath = Array.isArray(filePath) ? filePath.join('/') : (filePath ?? '');
 
   const contentType = mime.getType(path.basename(targetPath));
 

--- a/app/components/generate-report-button.tsx
+++ b/app/components/generate-report-button.tsx
@@ -9,19 +9,23 @@ import {
   ModalBody,
   useDisclosure,
   ModalFooter,
-  Input,
+  Autocomplete,
+  AutocompleteItem,
 } from '@nextui-org/react';
 import { useState } from 'react';
+
+import { type Result } from '../lib/storage';
 
 import useMutation from '@/app/hooks/useMutation';
 import ErrorMessage from '@/app/components/error-message';
 
 interface DeleteProjectButtonProps {
-  resultIds?: string[];
+  results: Result[];
+  projects: string[];
   onGeneratedReport?: () => void;
 }
 
-export default function GenerateReportButton({ resultIds, onGeneratedReport }: DeleteProjectButtonProps) {
+export default function GenerateReportButton({ results, projects, onGeneratedReport }: DeleteProjectButtonProps) {
   const { mutate: generateReport, isLoading, error } = useMutation('/api/report/generate', { method: 'POST' });
 
   const [projectName, setProjectName] = useState('');
@@ -29,11 +33,11 @@ export default function GenerateReportButton({ resultIds, onGeneratedReport }: D
   const { isOpen, onOpen, onClose, onOpenChange } = useDisclosure();
 
   const GenerateReport = async () => {
-    if (!resultIds?.length) {
+    if (!results?.length) {
       return;
     }
 
-    await generateReport({ resultsIds: resultIds, project: projectName });
+    await generateReport({ resultsIds: results.map((r) => r.resultID), project: projectName });
 
     setProjectName('');
     onClose();
@@ -44,7 +48,7 @@ export default function GenerateReportButton({ resultIds, onGeneratedReport }: D
     <>
       {error && <ErrorMessage message={error.message} />}
       <Tooltip color="secondary" content="Generate Report" placement="top">
-        <Button color="secondary" isDisabled={!resultIds?.length} isLoading={isLoading} size="md" onClick={onOpen}>
+        <Button color="secondary" isDisabled={!results?.length} isLoading={isLoading} size="md" onClick={onOpen}>
           Generate Report
         </Button>
       </Tooltip>
@@ -54,12 +58,17 @@ export default function GenerateReportButton({ resultIds, onGeneratedReport }: D
             <>
               <ModalHeader className="flex flex-col gap-1">Generate report</ModalHeader>
               <ModalBody>
-                <Input
-                  isDisabled={isLoading}
-                  label="Project"
-                  placeholder="project name, could be empty"
-                  onChange={(e) => setProjectName(e.target.value)}
-                />
+                <Autocomplete
+                  allowsCustomValue
+                  defaultInputValue={projects.at(0) ?? ''}
+                  items={projects.map((project) => ({ label: project, value: project }))}
+                  label="Project name"
+                  placeholder="leave empty if not required"
+                  onInputChange={(value) => setProjectName(value)}
+                  onSelectionChange={(value) => setProjectName(value?.toString() ?? '')}
+                >
+                  {(item) => <AutocompleteItem key={item.value}>{item.label}</AutocompleteItem>}
+                </Autocomplete>
               </ModalBody>
               <ModalFooter>
                 <Button color="danger" isDisabled={isLoading} onClick={onClose}>

--- a/app/components/generate-report-button.tsx
+++ b/app/components/generate-report-button.tsx
@@ -1,6 +1,17 @@
 'use client';
 
-import { Tooltip, Button } from '@nextui-org/react';
+import {
+  Tooltip,
+  Button,
+  Modal,
+  ModalContent,
+  ModalHeader,
+  ModalBody,
+  useDisclosure,
+  ModalFooter,
+  Input,
+} from '@nextui-org/react';
+import { useState } from 'react';
 
 import useMutation from '@/app/hooks/useMutation';
 import ErrorMessage from '@/app/components/error-message';
@@ -13,13 +24,19 @@ interface DeleteProjectButtonProps {
 export default function GenerateReportButton({ resultIds, onGeneratedReport }: DeleteProjectButtonProps) {
   const { mutate: generateReport, isLoading, error } = useMutation('/api/report/generate', { method: 'POST' });
 
+  const [projectName, setProjectName] = useState('');
+
+  const { isOpen, onOpen, onClose, onOpenChange } = useDisclosure();
+
   const GenerateReport = async () => {
     if (!resultIds?.length) {
       return;
     }
 
-    await generateReport({ resultsIds: resultIds });
+    await generateReport({ resultsIds: resultIds, project: projectName });
 
+    setProjectName('');
+    onClose();
     onGeneratedReport?.();
   };
 
@@ -27,16 +44,35 @@ export default function GenerateReportButton({ resultIds, onGeneratedReport }: D
     <>
       {error && <ErrorMessage message={error.message} />}
       <Tooltip color="secondary" content="Generate Report" placement="top">
-        <Button
-          color="secondary"
-          isDisabled={!resultIds?.length}
-          isLoading={isLoading}
-          size="md"
-          onClick={GenerateReport}
-        >
+        <Button color="secondary" isDisabled={!resultIds?.length} isLoading={isLoading} size="md" onClick={onOpen}>
           Generate Report
         </Button>
       </Tooltip>
+      <Modal isOpen={isOpen} onOpenChange={onOpenChange}>
+        <ModalContent>
+          {(onClose) => (
+            <>
+              <ModalHeader className="flex flex-col gap-1">Generate report</ModalHeader>
+              <ModalBody>
+                <Input
+                  isDisabled={isLoading}
+                  label="Project"
+                  placeholder="project name, could be empty"
+                  onChange={(e) => setProjectName(e.target.value)}
+                />
+              </ModalBody>
+              <ModalFooter>
+                <Button color="danger" isDisabled={isLoading} onClick={onClose}>
+                  Close
+                </Button>
+                <Button color="success" isLoading={isLoading} type="submit" onClick={GenerateReport}>
+                  Generate
+                </Button>
+              </ModalFooter>
+            </>
+          )}
+        </ModalContent>
+      </Modal>
     </>
   );
 }

--- a/app/components/icons.tsx
+++ b/app/components/icons.tsx
@@ -191,3 +191,25 @@ export const EyeIcon: React.FC<IconSvgProps> = (props) => (
     />
   </svg>
 );
+
+export const SearchIcon: React.FC<IconSvgProps> = (props) => (
+  <svg
+    aria-hidden="true"
+    fill="none"
+    focusable="false"
+    height="1em"
+    role="presentation"
+    viewBox="0 0 24 24"
+    width="1em"
+    {...props}
+  >
+    <path
+      d="M11.5 21C16.7467 21 21 16.7467 21 11.5C21 6.25329 16.7467 2 11.5 2C6.25329 2 2 6.25329 2 11.5C2 16.7467 6.25329 21 11.5 21Z"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth="2"
+    />
+    <path d="M22 22L20 20" stroke="currentColor" strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" />
+  </svg>
+);

--- a/app/components/project-select.tsx
+++ b/app/components/project-select.tsx
@@ -1,0 +1,53 @@
+'use client';
+
+import { Select, SelectItem, SharedSelection } from '@nextui-org/react';
+
+import useQuery from '../hooks/useQuery';
+import { defaultProjectName } from '../lib/constants';
+
+import ErrorMessage from './error-message';
+
+interface ProjectSelectProps {
+  onSelect: (project: string) => void;
+  refreshId?: string;
+}
+
+export default function ProjectSelect({ refreshId, onSelect }: ProjectSelectProps) {
+  const { data: projects, error, isLoading } = useQuery<string[]>('/api/project/list', { dependencies: [refreshId] });
+
+  const items = [defaultProjectName, ...(projects ?? [])];
+
+  const onChange = (keys: SharedSelection) => {
+    if (keys === defaultProjectName.toString()) {
+      onSelect?.(defaultProjectName);
+
+      return;
+    }
+
+    if (!keys.currentKey) {
+      return;
+    }
+
+    onSelect?.(keys.currentKey);
+  };
+
+  return (
+    <>
+      {error && <ErrorMessage message={error.message ?? ''} />}
+      <Select
+        disallowEmptySelection
+        className="pt-1 max-w-[30%]"
+        defaultSelectedKeys={[defaultProjectName]}
+        isDisabled={items.length <= 1}
+        isLoading={isLoading}
+        label="project"
+        size="lg"
+        onSelectionChange={onChange}
+      >
+        {items.map((project) => (
+          <SelectItem key={project}>{project}</SelectItem>
+        ))}
+      </Select>
+    </>
+  );
+}

--- a/app/components/report-trends.tsx
+++ b/app/components/report-trends.tsx
@@ -1,6 +1,11 @@
 'use client';
 
 import { Spinner } from '@nextui-org/react';
+import { useState } from 'react';
+
+import { defaultProjectName } from '../lib/constants';
+
+import ProjectSelect from './project-select';
 
 import { TrendChart } from '@/app/components/trend-chart';
 import { title } from '@/app/components/primitives';
@@ -10,15 +15,17 @@ import { type ReportHistory } from '@/app/lib/storage';
 
 export default function ReportTrends() {
   const { data: reports, error, isLoading } = useQuery<ReportHistory[]>('/api/report/trend');
+  const [project, setProject] = useState(defaultProjectName);
 
   return (
     <>
-      <div>
+      <div className="flex flex-row justify-between">
         <h1 className={title()}>Trends</h1>
+        <ProjectSelect onSelect={setProject} />
       </div>
       {error && <ErrorMessage message={error.message} />}
       {isLoading && <Spinner />}
-      {!!reports?.length && <TrendChart reports={reports} />}
+      {!!reports?.length && <TrendChart project={project} reportHistory={reports} />}
     </>
   );
 }

--- a/app/components/reports.tsx
+++ b/app/components/reports.tsx
@@ -1,5 +1,12 @@
 'use client';
 
+import { useState } from 'react';
+import { v4 as uuidv4 } from 'uuid';
+
+import { defaultProjectName } from '../lib/constants';
+
+import ProjectSelect from './project-select';
+
 import ReportsTable from '@/app/components/reports-table';
 import { title } from '@/app/components/primitives';
 
@@ -8,13 +15,22 @@ interface ReportsProps {
 }
 
 export default function Reports({ onChange }: ReportsProps) {
+  const [refreshId, setRefreshId] = useState<string>(uuidv4());
+  const [project, setProject] = useState(defaultProjectName);
+
+  const updateView = () => {
+    onChange?.();
+    setRefreshId(uuidv4());
+  };
+
   return (
     <>
-      <div>
+      <div className="flex flex-row justify-between">
         <h1 className={title()}>Reports</h1>
+        <ProjectSelect refreshId={refreshId} onSelect={setProject} />
       </div>
       <br />
-      <ReportsTable onChange={onChange} />
+      <ReportsTable project={project} onChange={updateView} />
     </>
   );
 }

--- a/app/components/results-table.tsx
+++ b/app/components/results-table.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import {
   Table,
   TableHeader,
@@ -11,34 +11,52 @@ import {
   Chip,
   type Selection,
   Spinner,
+  Autocomplete,
+  AutocompleteItem,
 } from '@nextui-org/react';
+
+import { SearchIcon } from './icons';
 
 import useQuery from '@/app/hooks/useQuery';
 import ErrorMessage from '@/app/components/error-message';
 import FormattedDate from '@/app/components/date-format';
 import { type Result } from '@/app/lib/storage';
 import DeleteResultsButton from '@/app/components/delete-results-button';
+import { getUniqueProjectsList } from '@/app/lib/storage/format';
 
 const columns = [
   { name: 'ID', uid: 'resultID' },
+  { name: 'Project', uid: 'project' },
   { name: 'Created At', uid: 'createdAt' },
   { name: 'Tags', uid: 'tags' },
   { name: 'Actions', uid: 'actions' },
 ];
 
 const getTags = (item: Result) => {
-  return Object.entries(item).filter(([key]) => !['resultID', 'createdAt'].includes(key));
+  return Object.entries(item).filter(([key]) => !['resultID', 'createdAt', 'project'].includes(key));
 };
 
 interface ResultsTableProps {
   refreshId: string;
   selected?: string[];
-  onSelect?: (keys: string[]) => void;
+  onSelect?: (results: Result[]) => void;
   onDeleted?: () => void;
 }
 
 export default function ResultsTable({ refreshId, onSelect, onDeleted, selected }: ResultsTableProps) {
   const { data: results, error, isLoading, refetch } = useQuery<Result[]>('/api/result/list');
+
+  const projects = getUniqueProjectsList(results ?? []);
+
+  const [projectFilter, setProjectFilter] = useState('');
+
+  const filteredResults = React.useMemo(() => {
+    if (projectFilter) {
+      return results?.filter((r) => r.project?.includes(projectFilter));
+    }
+
+    return results;
+  }, [results, projectFilter]);
 
   useEffect(() => {
     if (!isLoading) {
@@ -53,7 +71,7 @@ export default function ResultsTable({ refreshId, onSelect, onDeleted, selected 
 
   const onChangeSelect = (keys: Selection) => {
     if (keys === 'all') {
-      const all = (results ?? []).map((result) => result.resultID);
+      const all = results ?? [];
 
       onSelect?.(all);
     }
@@ -62,42 +80,72 @@ export default function ResultsTable({ refreshId, onSelect, onDeleted, selected 
       return;
     }
 
-    const selected = Array.from(keys) as string[];
+    const selectedKeys = Array.from(keys);
+    const selectedResults = results?.filter((r) => selectedKeys.includes(r.resultID)) ?? [];
 
-    onSelect?.(selected);
+    onSelect?.(selectedResults);
   };
 
   return error ? (
     <ErrorMessage message={error.message} />
   ) : (
-    <Table aria-label="Results" selectedKeys={selected} selectionMode="multiple" onSelectionChange={onChangeSelect}>
-      <TableHeader columns={columns}>
-        {(column) => (
-          <TableColumn key={column.uid} align={column.uid === 'actions' ? 'center' : 'start'}>
-            {column.name}
-          </TableColumn>
-        )}
-      </TableHeader>
-      <TableBody emptyContent="No results" isLoading={isLoading} items={results ?? []} loadingContent={<Spinner />}>
-        {(item) => (
-          <TableRow key={item.resultID}>
-            <TableCell className="w-1/3">{item.resultID}</TableCell>
-            <TableCell className="w-1/6">
-              <FormattedDate date={new Date(item.createdAt)} />
-            </TableCell>
-            <TableCell className="w-1/3">
-              {getTags(item).map(([key, value], index) => (
-                <Chip key={index} className="m-1 p-5 text-nowrap" color="primary" size="sm">{`${key}: ${value}`}</Chip>
-              ))}
-            </TableCell>
-            <TableCell className="w-1/12">
-              <div className="flex gap-4 justify-center">
-                <DeleteResultsButton resultIds={[item.resultID]} onDeletedResult={shouldRefetch} />
-              </div>
-            </TableCell>
-          </TableRow>
-        )}
-      </TableBody>
-    </Table>
+    <>
+      <Autocomplete
+        allowsCustomValue
+        aria-label="filter by project name"
+        className="pt-1 mb-5 max-w-[30%]"
+        isDisabled={!projects.length}
+        placeholder="filter by project name"
+        size="lg"
+        startContent={<SearchIcon />}
+        value={projectFilter}
+        onInputChange={(value) => setProjectFilter(value)}
+        onSelectionChange={(value) => setProjectFilter(value?.toString() ?? '')}
+      >
+        {projects.map((project) => (
+          <AutocompleteItem key={project}>{project}</AutocompleteItem>
+        ))}
+      </Autocomplete>
+      <Table aria-label="Results" selectedKeys={selected} selectionMode="multiple" onSelectionChange={onChangeSelect}>
+        <TableHeader columns={columns}>
+          {(column) => (
+            <TableColumn key={column.uid} align={column.uid === 'actions' ? 'center' : 'start'}>
+              {column.name}
+            </TableColumn>
+          )}
+        </TableHeader>
+        <TableBody
+          emptyContent="No results."
+          isLoading={isLoading}
+          items={filteredResults ?? []}
+          loadingContent={<Spinner />}
+        >
+          {(item) => (
+            <TableRow key={item.resultID}>
+              <TableCell className="w-1/3">{item.resultID}</TableCell>
+              <TableCell className="w-1/6">{item.project}</TableCell>
+              <TableCell className="w-1/12">
+                <FormattedDate date={new Date(item.createdAt)} />
+              </TableCell>
+              <TableCell className="w-1/3">
+                {getTags(item).map(([key, value], index) => (
+                  <Chip
+                    key={index}
+                    className="m-1 p-5 text-nowrap"
+                    color="primary"
+                    size="sm"
+                  >{`${key}: ${value}`}</Chip>
+                ))}
+              </TableCell>
+              <TableCell className="w-1/12">
+                <div className="flex gap-4 justify-center">
+                  <DeleteResultsButton resultIds={[item.resultID]} onDeletedResult={shouldRefetch} />
+                </div>
+              </TableCell>
+            </TableRow>
+          )}
+        </TableBody>
+      </Table>
+    </>
   );
 }

--- a/app/components/results.tsx
+++ b/app/components/results.tsx
@@ -3,18 +3,24 @@
 import { useState } from 'react';
 import { v4 as uuidv4 } from 'uuid';
 
+import { type Result } from '@/app/lib/storage';
 import ResultsTable from '@/app/components/results-table';
 import { title } from '@/app/components/primitives';
 import GenerateReportButton from '@/app/components/generate-report-button';
 import DeleteResultsButton from '@/app/components/delete-results-button';
+import { getUniqueProjectsList } from '@/app/lib/storage/format';
 
 interface ResultsProps {
   onChange: () => void;
 }
 
 export default function Results({ onChange }: ResultsProps) {
-  const [selectedResults, setSelectedResults] = useState<string[]>([]);
+  const [selectedResults, setSelectedResults] = useState<Result[]>([]);
   const [refreshId, setRefreshId] = useState<string>(uuidv4());
+
+  const selectedResultIds = selectedResults.map((r) => r.resultID);
+
+  const projects = getUniqueProjectsList(selectedResults);
 
   const onListUpdate = () => {
     setSelectedResults([]);
@@ -33,14 +39,14 @@ export default function Results({ onChange }: ResultsProps) {
           <h1 className={title()}>Results</h1>
         </div>
         <div className="flex gap-2 w-2/3 flex-wrap justify-end mr-7">
-          <GenerateReportButton resultIds={selectedResults} onGeneratedReport={onListUpdate} />
-          <DeleteResultsButton resultIds={selectedResults} onDeletedResult={onDelete} />
+          <GenerateReportButton projects={projects} results={selectedResults} onGeneratedReport={onListUpdate} />
+          <DeleteResultsButton resultIds={selectedResultIds} onDeletedResult={onDelete} />
         </div>
       </div>
       <br />
       <ResultsTable
         refreshId={refreshId}
-        selected={selectedResults}
+        selected={selectedResultIds}
         onDeleted={onDelete}
         onSelect={setSelectedResults}
       />

--- a/app/hooks/useQuery.ts
+++ b/app/hooks/useQuery.ts
@@ -3,7 +3,7 @@ import { useRouter } from 'next/navigation';
 
 import { useApiToken } from '@/app/providers/ApiTokenProvider';
 
-const useQuery = <ReturnType>(path: string, options?: RequestInit) => {
+const useQuery = <ReturnType>(path: string, options?: RequestInit & { dependencies: unknown[] }) => {
   const [data, setData] = useState<ReturnType | null>(null);
   const [isLoading, setLoading] = useState(false);
   const [error, setError] = useState<Error | null>(null);
@@ -46,7 +46,7 @@ const useQuery = <ReturnType>(path: string, options?: RequestInit) => {
     } finally {
       setLoading(false);
     }
-  }, [path, options]);
+  }, [path, options, ...(options?.dependencies ?? [])]);
 
   useEffect(() => {
     if (!isClientAuthorized()) {

--- a/app/lib/constants.ts
+++ b/app/lib/constants.ts
@@ -1,3 +1,5 @@
 export const serveReportRoute = '/api/serve';
 
 export const reportAuthCookieName = 'auth';
+
+export const defaultProjectName = 'all';

--- a/app/lib/pw.ts
+++ b/app/lib/pw.ts
@@ -8,13 +8,15 @@ import { REPORTS_FOLDER, TMP_FOLDER } from './storage/constants';
 
 const execAsync = util.promisify(exec);
 
-export const generatePlaywrightReport = async (): Promise<{ reportId: UUID; reportPath: string }> => {
+export const generatePlaywrightReport = async (
+  projectName?: string,
+): Promise<{ reportId: UUID; reportPath: string }> => {
   console.log(`[pw] generating Playwright report`);
   const reportId = randomUUID();
 
   console.log(`[pw] report ID: ${reportId}`);
 
-  const reportPath = path.join(REPORTS_FOLDER, reportId);
+  const reportPath = path.join(REPORTS_FOLDER, projectName ?? '', reportId);
 
   console.log(`[pw] report path: ${reportPath}`);
 

--- a/app/lib/storage/format.ts
+++ b/app/lib/storage/format.ts
@@ -1,3 +1,9 @@
+import { Result, Report } from './types';
+
 export const bytesToString = (bytes: number): string => {
   return `${(bytes / 1000 / 1000).toFixed(2)} MB`;
+};
+
+export const getUniqueProjectsList = (items: (Result | Report)[]): string[] => {
+  return Array.from(new Set(items.map((r) => r.project).filter(Boolean)));
 };

--- a/app/lib/storage/fs.ts
+++ b/app/lib/storage/fs.ts
@@ -4,7 +4,7 @@ import { randomUUID } from 'node:crypto';
 
 import getFolderSize from 'get-folder-size';
 
-import { bytesToString } from './format';
+import { bytesToString, getUniqueProjectsList } from './format';
 import { DATA_FOLDER, REPORTS_FOLDER, REPORTS_PATH, RESULTS_FOLDER, TMP_FOLDER } from './constants';
 
 import { generatePlaywrightReport } from '@/app/lib/pw';
@@ -167,7 +167,7 @@ export async function generateReport(resultsIds: string[], project?: string) {
 export async function getProjects(): Promise<string[]> {
   const reports = await readReports();
 
-  return Array.from(new Set(reports.map((r) => r.project))).filter(Boolean);
+  return getUniqueProjectsList(reports);
 }
 
 export async function moveReport(oldPath: string, newPath: string): Promise<void> {

--- a/app/lib/storage/s3.ts
+++ b/app/lib/storage/s3.ts
@@ -4,7 +4,7 @@ import path from 'node:path';
 
 import { type BucketItem, Client } from 'minio';
 
-import { bytesToString } from './format';
+import { bytesToString, getUniqueProjectsList } from './format';
 import { REPORTS_FOLDER, TMP_FOLDER, REPORTS_BUCKET, RESULTS_BUCKET, REPORTS_PATH } from './constants';
 
 import { serveReportRoute } from '@/app/lib/constants';
@@ -451,7 +451,7 @@ export class S3 {
 
     const reports = await this.readReports();
 
-    return Array.from(new Set(reports.map((r) => r.project))).filter(Boolean);
+    return getUniqueProjectsList(reports);
   }
 
   async moveReport(oldPath: string, newPath: string): Promise<void> {

--- a/app/lib/storage/s3.ts
+++ b/app/lib/storage/s3.ts
@@ -5,7 +5,7 @@ import path from 'node:path';
 import { type BucketItem, Client } from 'minio';
 
 import { bytesToString } from './format';
-import { REPORTS_FOLDER, TMP_FOLDER, REPORTS_BUCKET, RESULTS_BUCKET } from './constants';
+import { REPORTS_FOLDER, TMP_FOLDER, REPORTS_BUCKET, RESULTS_BUCKET, REPORTS_PATH } from './constants';
 
 import { serveReportRoute } from '@/app/lib/constants';
 import { generatePlaywrightReport } from '@/app/lib/pw';
@@ -191,7 +191,7 @@ export class S3 {
     const { result, error } = await this.read(targetPath, contentType);
 
     if (error) {
-      console.error(`[s3] failed to read file: ${error.message}`);
+      console.error(`[s3] failed to read file ${targetPath}: ${error.message}`);
       throw new Error(`[s3] failed to read file: ${error.message}`);
     }
 
@@ -283,12 +283,17 @@ export class S3 {
 
         console.log(`[s3] reading report: ${JSON.stringify(file)}`);
 
-        const id = path.basename(path.dirname(file.name));
+        const dir = path.dirname(file.name);
+        const id = path.basename(dir);
+        const parentDir = path.basename(path.dirname(dir));
+
+        const projectName = parentDir === REPORTS_PATH ? '' : parentDir;
 
         reports.push({
           reportID: id,
+          project: projectName,
           createdAt: file.lastModified,
-          reportUrl: `${serveReportRoute}/${id}/index.html`,
+          reportUrl: `${serveReportRoute}/${projectName ? encodeURIComponent(projectName) : ''}/${id}/index.html`,
         });
       });
 
@@ -308,8 +313,8 @@ export class S3 {
     await withError(this.clear(...objects));
   }
 
-  private async getReportObjects(reportId: string): Promise<string[]> {
-    const reportStream = this.client.listObjectsV2(this.bucket, `${REPORTS_BUCKET}/${reportId}`, true);
+  private async getReportObjects(reportsIDs: string[]): Promise<string[]> {
+    const reportStream = this.client.listObjectsV2(this.bucket, REPORTS_BUCKET, true);
 
     const files: string[] = [];
 
@@ -319,7 +324,11 @@ export class S3 {
           return;
         }
 
-        files.push(file.name);
+        const reportID = path.basename(path.dirname(file.name));
+
+        if (reportsIDs.includes(reportID)) {
+          files.push(file.name);
+        }
       });
 
       reportStream.on('error', (err) => {
@@ -333,11 +342,9 @@ export class S3 {
   }
 
   async deleteReports(reportIDs: string[]): Promise<void> {
-    for (const id of reportIDs) {
-      const objects = await this.getReportObjects(id);
+    const objects = await this.getReportObjects(reportIDs);
 
-      await withError(this.clear(...objects));
-    }
+    await withError(this.clear(...objects));
   }
 
   async saveResult(buffer: Buffer, resultDetails: ResultDetails): Promise<{ resultID: UUID; createdAt: string }> {
@@ -375,8 +382,11 @@ export class S3 {
 
       console.log(`[s3] uploading file: ${JSON.stringify(file)}`);
 
+      const projectName = file.path.split(REPORTS_PATH).pop()?.split(reportId).shift();
+
+      console.log(`[s3] project name: ${projectName}`);
       const nestedPath = file.path.split(reportId).pop();
-      const s3Path = `/${REPORTS_BUCKET}/${reportId}/${nestedPath}/${file.name}`;
+      const s3Path = `/${REPORTS_BUCKET}${projectName ?? '/'}${reportId}/${nestedPath}/${file.name}`;
 
       console.log(`[s3] uploading to ${s3Path}`);
 
@@ -395,7 +405,7 @@ export class S3 {
     await withError(fs.rm(REPORTS_FOLDER, { recursive: true, force: true }));
   };
 
-  async generateReport(resultsIds: string[]): Promise<UUID> {
+  async generateReport(resultsIds: string[], project?: string): Promise<UUID> {
     console.log(`[s3] generate report from results: ${JSON.stringify(resultsIds)}`);
     await this.clearTempFolders();
 
@@ -426,7 +436,7 @@ export class S3 {
       }
     }
 
-    const { reportPath, reportId } = await generatePlaywrightReport();
+    const { reportPath, reportId } = await generatePlaywrightReport(project);
 
     console.log(`[s3] report generated: ${reportId} | ${reportPath}`);
 
@@ -434,5 +444,34 @@ export class S3 {
     await this.clearTempFolders();
 
     return reportId;
+  }
+
+  async getProjects(): Promise<string[]> {
+    console.log(`[s3] get projects`);
+
+    const reports = await this.readReports();
+
+    return Array.from(new Set(reports.map((r) => r.project))).filter(Boolean);
+  }
+
+  async moveReport(oldPath: string, newPath: string): Promise<void> {
+    console.log(`[s3] move report: ${oldPath} to ${newPath}`);
+
+    const reportPath = path.join(REPORTS_BUCKET, oldPath);
+
+    const objectStream = this.client.listObjectsV2(this.bucket, reportPath, true);
+
+    for await (const obj of objectStream) {
+      if (!obj.name) {
+        return;
+      }
+      const newObjectName = obj.name.replace(oldPath, newPath);
+
+      await this.client.copyObject(this.bucket, newObjectName, `${REPORTS_BUCKET}/${obj.name}`);
+
+      await this.client.removeObject(this.bucket, obj.name);
+    }
+
+    console.log(`Folder renamed from ${oldPath} to ${newPath}`);
   }
 }

--- a/app/lib/storage/types.ts
+++ b/app/lib/storage/types.ts
@@ -29,6 +29,7 @@ export interface ResultDetails {
 export type Result = {
   resultID: UUID;
   createdAt: string;
+  project: string;
 } & ResultDetails;
 
 export type Report = { reportID: string; project: string; reportUrl: string; createdAt: Date };

--- a/app/lib/storage/types.ts
+++ b/app/lib/storage/types.ts
@@ -16,7 +16,9 @@ export interface Storage {
     resultID: UUID;
     createdAt: string;
   }>;
-  generateReport: (resultsIds: string[]) => Promise<UUID>;
+  generateReport: (resultsIds: string[], project?: string) => Promise<UUID>;
+  getProjects: () => Promise<string[]>;
+  moveReport: (oldPath: string, newPath: string) => Promise<void>;
 }
 
 // For custom user fields
@@ -29,7 +31,7 @@ export type Result = {
   createdAt: string;
 } & ResultDetails;
 
-export type Report = { reportID: string; reportUrl: string; createdAt: Date };
+export type Report = { reportID: string; project: string; reportUrl: string; createdAt: Date };
 
 export type ReportHistory = Report & ReportInfo;
 

--- a/app/report/[id]/page.tsx
+++ b/app/report/[id]/page.tsx
@@ -71,7 +71,7 @@ function ReportDetail({ params }: Readonly<ReportDetailProps>) {
       <div className="flex md:flex-row flex-col gap-2">
         <div className="flex flex-col items-center md:w-1/4 max-w-full">
           <ReportStatistics stats={report?.stats} />
-          <Link href={`${serveReportRoute}/${params.id}/index.html`} target="_blank">
+          <Link href={report?.reportUrl ?? ''} target="_blank">
             <Button as="a" color="primary">
               Open report
             </Button>

--- a/readme.md
+++ b/readme.md
@@ -81,11 +81,13 @@ Response example:
   {
     "reportID": "8e9af87d-1d10-4729-aefd-3e92ee64d06c",
     "createdAt": "2024-05-06T16:52:45.017Z",
+    "project": "regression",
     "reportUrl": "/data/reports/8e9af87d-1d10-4729-aefd-3e92ee64d06c/index.html"
   },
   {
     "reportID": "8fe427ed-783c-4fb9-aacc-ba6fbc5f5667",
     "createdAt": "2024-05-06T16:59:38.814Z",
+    "project": "smoke",
     "reportUrl": "/data/reports/8fe427ed-783c-4fb9-aacc-ba6fbc5f5667/index.html"
   }
 ]
@@ -124,6 +126,7 @@ curl --location 'http://localhost:3000/api/report/generate' \
 --header 'Content-Type: application/json' \
 --header 'Authorization: <api-token>' \
 --data '{
+    "project": "regression",
     "resultsIds": [
         "b1d29907-7efa-48e8-a8d1-db49cf5c2998",
         "a7beb04b-f190-4fbb-bebd-58b2c776e6c3",
@@ -135,6 +138,7 @@ Response example:
 
 ```json
 {
+  "project": "regression",
   "reportId": "8e9af87d-1d10-4729-aefd-3e92ee64d06c",
   "reportUrl": "/data/reports/8e9af87d-1d10-4729-aefd-3e92ee64d06c/index.html"
 }
@@ -155,6 +159,7 @@ Response will contain array of results:
   {
     "resultID": "a7beb04b-f190-4fbb-bebd-58b2c776e6c3",
     "createdAt": "2024-05-06T16:40:33.021Z",
+    "project": "regression",
     "testRunName": "regression-run-v1.10",
     "reporter": "okhotemskyi"
   }


### PR DESCRIPTION
## Rationale
Having all results and reports stored in a single list makes it hard to distinguish them by just id and time of uploading. Moreover, usually on a project you would have separate runs like regression or smoke, as well as different product areas or teams. Thus a concept of a `project` could be introduced.

## Added

### Backend
- you can add a property `project` to results payload which will be separated from other tags
- reports location is changed from `/data/reports/reportID/` to `/data/reports/projectName/reportID/` (applies to local fs, s3 and reports serving)
- `/api/project/list` endpoint to make it simplier for ui to grab a list of projects available for reports
- `/api/report/generate` now can also accept `project` property


### UI
- result and report tables have a`project` column
- reports, results and trends could be filtered by project name
- when generating report a modal will be opened where you can select a project from list of results' projects or specify your own

## TODO
- to support uploading and generating reports right from a reporter we should update the [query](https://github.com/CyborgTests/reporter-playwright-reports-server/blob/ea653cbe2417e59fb2e3ec68d5c387f3398b3875/index.ts#L109) and pass a report name from a `resultDetails` or custom env variable.
- storage clients have method `moveReport` which will be used later as a part of feature to move report to another project folder, but will be implemented separately.
