### PR TITLE
feat: query report trends per project

### DIFF
--- a/app/api/report/generate/route.ts
+++ b/app/api/report/generate/route.ts
@@ -1,3 +1,4 @@
+import { serveReportRoute } from '@/app/lib/constants';
 import { storage } from '@/app/lib/storage';
 import { withError } from '@/app/lib/withError';
 
@@ -20,6 +21,6 @@ export async function POST(request: Request) {
   return Response.json({
     reportId,
     project,
-    reportUrl: `/data/reports/${project ? encodeURIComponent(project) : ''}/${reportId}/index.html`,
+    reportUrl: `${serveReportRoute}/${project ? encodeURI(project) : ''}/${reportId}/index.html`,
   });
 }

--- a/app/api/report/trend/route.ts
+++ b/app/api/report/trend/route.ts
@@ -1,13 +1,19 @@
 import path from 'node:path';
 
+import { type NextRequest } from 'next/server';
+
 import { storage } from '@/app/lib/storage';
 import { parse } from '@/app/lib/parser';
 import { sortReportsByCreatedDate } from '@/app/lib/sort';
 
 export const dynamic = 'force-dynamic'; // defaults to auto
 
-export async function GET() {
-  const reports = await storage.readReports();
+export async function GET(request: NextRequest) {
+  const { searchParams } = new URL(request.url);
+  const project = searchParams.get('project') ?? '';
+  const allReports = await storage.readReports();
+
+  const reports = allReports.filter((report) => (project ? report.project === project : report));
 
   const latestReports = sortReportsByCreatedDate(reports).slice(0, 20);
 

--- a/app/api/serve/[[...filePath]]/route.ts
+++ b/app/api/serve/[[...filePath]]/route.ts
@@ -21,6 +21,9 @@ export async function GET(
     params: ReportParams;
   },
 ) {
+  // is not protected by the middleware
+  // as we want to have callbackUrl in the query
+
   const session = await auth();
 
   const { filePath } = params;

--- a/app/components/project-select.tsx
+++ b/app/components/project-select.tsx
@@ -12,7 +12,7 @@ interface ProjectSelectProps {
   refreshId?: string;
 }
 
-export default function ProjectSelect({ refreshId, onSelect }: ProjectSelectProps) {
+export default function ProjectSelect({ refreshId, onSelect }: Readonly<ProjectSelectProps>) {
   const { data: projects, error, isLoading } = useQuery<string[]>('/api/project/list', { dependencies: [refreshId] });
 
   const items = [defaultProjectName, ...(projects ?? [])];

--- a/app/components/report-trends.tsx
+++ b/app/components/report-trends.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { Spinner } from '@nextui-org/react';
-import { useState } from 'react';
+import { useCallback } from 'react';
 
 import { defaultProjectName } from '../lib/constants';
 
@@ -14,18 +14,26 @@ import ErrorMessage from '@/app/components/error-message';
 import { type ReportHistory } from '@/app/lib/storage';
 
 export default function ReportTrends() {
-  const { data: reports, error, isLoading } = useQuery<ReportHistory[]>('/api/report/trend');
-  const [project, setProject] = useState(defaultProjectName);
+  const getProjectQueryParam = (project: string) =>
+    project === defaultProjectName ? '' : `?project=${encodeURIComponent(project)}`;
+
+  const getUrl = (project: string) => `/api/report/trend${getProjectQueryParam(project)}`;
+
+  const { data: reports, error, isLoading, refetch } = useQuery<ReportHistory[]>(getUrl(defaultProjectName));
+
+  const onProjectChange = useCallback((project: string) => {
+    refetch({ path: getUrl(project) });
+  }, []);
 
   return (
     <>
       <div className="flex flex-row justify-between">
         <h1 className={title()}>Trends</h1>
-        <ProjectSelect onSelect={setProject} />
+        {isLoading && <Spinner />}
+        <ProjectSelect onSelect={onProjectChange} />
       </div>
       {error && <ErrorMessage message={error.message} />}
-      {isLoading && <Spinner />}
-      {!!reports?.length && <TrendChart project={project} reportHistory={reports} />}
+      {!!reports?.length && <TrendChart reportHistory={reports} />}
     </>
   );
 }

--- a/app/components/trend-chart.tsx
+++ b/app/components/trend-chart.tsx
@@ -2,8 +2,6 @@
 import { Area, AreaChart, XAxis } from 'recharts';
 import Link from 'next/link';
 
-import { defaultProjectName } from '../lib/constants';
-
 import { type ReportHistory } from '@/app/lib/storage';
 import {
   type ChartConfig,
@@ -39,19 +37,16 @@ interface WithTotal {
 
 interface TrendChartProps {
   reportHistory: ReportHistory[];
-  project?: string;
 }
 
-export function TrendChart({ reportHistory, project }: Readonly<TrendChartProps>) {
-  const reports = project === defaultProjectName ? reportHistory : reportHistory.filter((r) => r.project === project);
-
+export function TrendChart({ reportHistory }: Readonly<TrendChartProps>) {
   const getPercentage = (value: number, total: number) => (value / total) * 100;
 
   const openInNewTab = (url: string) => {
     typeof window !== 'undefined' && window.open(url, '_blank', 'noopener,noreferrer');
   };
 
-  const chartData = reports.map((r) => ({
+  const chartData = reportHistory.map((r) => ({
     date: new Date(r.createdAt).getTime(),
     passed: getPercentage(r.stats.expected, r.stats.total),
     passedCount: r.stats.expected,
@@ -67,7 +62,7 @@ export function TrendChart({ reportHistory, project }: Readonly<TrendChartProps>
 
   return (
     <ChartContainer config={chartConfig}>
-      {reports.length <= 1 ? (
+      {reportHistory.length <= 1 ? (
         <span>Not enough data for trend chart</span>
       ) : (
         <AreaChart

--- a/app/hooks/useQuery.ts
+++ b/app/hooks/useQuery.ts
@@ -16,36 +16,39 @@ const useQuery = <ReturnType>(
 
   const apiToken = useMemo(() => session?.data?.user?.apiToken, [session]);
 
-  const fetchData = useCallback(async () => {
-    setLoading(true);
-    setError(null);
-    try {
-      const headers = !!apiToken
-        ? {
-            Authorization: apiToken,
-          }
-        : undefined;
+  const fetchData = useCallback(
+    async (opts?: { path: string }) => {
+      setLoading(true);
+      setError(null);
+      try {
+        const headers = apiToken
+          ? {
+              Authorization: apiToken,
+            }
+          : undefined;
 
-      const response = await fetch(path, {
-        headers,
-        body: options?.body ? JSON.stringify(options.body) : undefined,
-        method: options?.method ?? 'GET',
-      });
+        const response = await fetch(opts?.path ?? path, {
+          headers,
+          body: options?.body ? JSON.stringify(options.body) : undefined,
+          method: options?.method ?? 'GET',
+        });
 
-      if (!response.ok) {
-        throw new Error(`Network response was not ok: ${await response.text()}`);
+        if (!response.ok) {
+          throw new Error(`Network response was not ok: ${await response.text()}`);
+        }
+        const jsonData = await response.json();
+
+        setData(jsonData);
+      } catch (err) {
+        if (err instanceof Error) {
+          setError(err);
+        }
+      } finally {
+        setLoading(false);
       }
-      const jsonData = await response.json();
-
-      setData(jsonData);
-    } catch (err) {
-      if (err instanceof Error) {
-        setError(err);
-      }
-    } finally {
-      setLoading(false);
-    }
-  }, [path, options, apiToken, ...(options?.dependencies ?? [])]);
+    },
+    [path, options, apiToken, ...(options?.dependencies ?? [])],
+  );
 
   useEffect(() => {
     if (session.status === 'unauthenticated') {

--- a/readme.md
+++ b/readme.md
@@ -82,13 +82,13 @@ Response example:
     "reportID": "8e9af87d-1d10-4729-aefd-3e92ee64d06c",
     "createdAt": "2024-05-06T16:52:45.017Z",
     "project": "regression",
-    "reportUrl": "/data/reports/8e9af87d-1d10-4729-aefd-3e92ee64d06c/index.html"
+    "reportUrl": "/api/serve/regression/8e9af87d-1d10-4729-aefd-3e92ee64d06c/index.html"
   },
   {
     "reportID": "8fe427ed-783c-4fb9-aacc-ba6fbc5f5667",
     "createdAt": "2024-05-06T16:59:38.814Z",
     "project": "smoke",
-    "reportUrl": "/data/reports/8fe427ed-783c-4fb9-aacc-ba6fbc5f5667/index.html"
+    "reportUrl": "/api/serve/smoke/8fe427ed-783c-4fb9-aacc-ba6fbc5f5667/index.html"
   }
 ]
 ```
@@ -140,7 +140,7 @@ Response example:
 {
   "project": "regression",
   "reportId": "8e9af87d-1d10-4729-aefd-3e92ee64d06c",
-  "reportUrl": "/data/reports/8e9af87d-1d10-4729-aefd-3e92ee64d06c/index.html"
+  "reportUrl": "/api/serve/regression/8e9af87d-1d10-4729-aefd-3e92ee64d06c/index.html"
 }
 ```
 


### PR DESCRIPTION
## Rationale
Currently we have trends implementation that uses 20 latest reports and just filters them by project. We need to query latest reports per selected project.

## Added
- `/api/report/trend` now supports query param `project`
- Trends tab now fetches latest reports per selected project

## Fixed
- `/api/report/generate` now returns proper report Url
- example report urls in readme