### PR TITLE
feat: storage pagination

### DIFF
--- a/app/api/report/[id]/route.ts
+++ b/app/api/report/[id]/route.ts
@@ -24,13 +24,13 @@ export async function GET(
     return new Response('report ID is required', { status: 400 });
   }
 
-  const { result: stats, error: statsError } = await withError(storage.readReports());
+  const { result: stats, error: statsError } = await withError(storage.readReports({ ids: [id] }));
 
   if (statsError || !stats) {
     return new Response(`failed to read reports: ${statsError?.message ?? 'unknown error'}`, { status: 500 });
   }
 
-  const reportStats = stats.find((r) => r.reportID === id);
+  const reportStats = stats.reports.find((r) => r.reportID === id);
 
   const { result: html, error } = await withError(
     storage.readFile(path.join(reportStats?.project ?? '', id, 'index.html'), 'text/html'),

--- a/app/api/report/list/route.ts
+++ b/app/api/report/list/route.ts
@@ -1,15 +1,21 @@
-import { sortReportsByCreatedDate } from '@/app/lib/sort';
+import { type NextRequest } from 'next/server';
+
 import { storage } from '@/app/lib/storage';
 import { withError } from '@/app/lib/withError';
+import { parseFromRequest } from '@/app/lib/storage/pagination';
 
 export const dynamic = 'force-dynamic'; // defaults to auto
 
-export async function GET() {
-  const { result: reports, error } = await withError(storage.readReports());
+export async function GET(request: NextRequest) {
+  const { searchParams } = new URL(request.url);
+  const pagination = parseFromRequest(searchParams);
+  const project = searchParams.get('project') ?? '';
+
+  const { result: reports, error } = await withError(storage.readReports({ pagination, project }));
 
   if (error) {
     return new Response(error.message, { status: 400 });
   }
 
-  return Response.json(sortReportsByCreatedDate(reports!));
+  return Response.json(reports!);
 }

--- a/app/api/report/projects/route.ts
+++ b/app/api/report/projects/route.ts
@@ -1,10 +1,8 @@
 import { storage } from '@/app/lib/storage';
 import { withError } from '@/app/lib/withError';
 
-export const dynamic = 'force-dynamic'; // defaults to auto
-
 export async function GET() {
-  const { result: projects, error } = await withError(storage.getProjects());
+  const { result: projects, error } = await withError(storage.getReportsProjects());
 
   if (error) {
     return new Response(error.message, { status: 400 });

--- a/app/api/report/projects/route.ts
+++ b/app/api/report/projects/route.ts
@@ -1,6 +1,8 @@
 import { storage } from '@/app/lib/storage';
 import { withError } from '@/app/lib/withError';
 
+export const dynamic = 'force-dynamic'; // defaults to auto
+
 export async function GET() {
   const { result: projects, error } = await withError(storage.getReportsProjects());
 

--- a/app/api/report/trend/route.ts
+++ b/app/api/report/trend/route.ts
@@ -4,18 +4,15 @@ import { type NextRequest } from 'next/server';
 
 import { storage } from '@/app/lib/storage';
 import { parse } from '@/app/lib/parser';
-import { sortReportsByCreatedDate } from '@/app/lib/sort';
 
 export const dynamic = 'force-dynamic'; // defaults to auto
 
 export async function GET(request: NextRequest) {
   const { searchParams } = new URL(request.url);
   const project = searchParams.get('project') ?? '';
-  const allReports = await storage.readReports();
+  const { reports } = await storage.readReports({ project });
 
-  const reports = allReports.filter((report) => (project ? report.project === project : report));
-
-  const latestReports = sortReportsByCreatedDate(reports).slice(0, 20);
+  const latestReports = reports.slice(0, 20);
 
   const latestReportsInfo = await Promise.all(
     latestReports.map(async (report) => {

--- a/app/api/result/delete/route.ts
+++ b/app/api/result/delete/route.ts
@@ -1,5 +1,3 @@
-import { revalidateTag } from 'next/cache';
-
 import { storage } from '@/app/lib/storage';
 import { withError } from '@/app/lib/withError';
 
@@ -17,8 +15,6 @@ export async function DELETE(request: Request) {
   if (error) {
     return new Response(error.message, { status: 404 });
   }
-
-  revalidateTag('projects');
 
   return Response.json({
     message: `Results files deleted successfully`,

--- a/app/api/result/delete/route.ts
+++ b/app/api/result/delete/route.ts
@@ -1,3 +1,5 @@
+import { revalidateTag } from 'next/cache';
+
 import { storage } from '@/app/lib/storage';
 import { withError } from '@/app/lib/withError';
 
@@ -15,6 +17,8 @@ export async function DELETE(request: Request) {
   if (error) {
     return new Response(error.message, { status: 404 });
   }
+
+  revalidateTag('projects');
 
   return Response.json({
     message: `Results files deleted successfully`,

--- a/app/api/result/list/route.ts
+++ b/app/api/result/list/route.ts
@@ -1,14 +1,21 @@
+import { type NextRequest } from 'next/server';
+
 import { storage } from '@/app/lib/storage';
 import { withError } from '@/app/lib/withError';
+import { parseFromRequest } from '@/app/lib/storage/pagination';
 
 export const dynamic = 'force-dynamic'; // defaults to auto
 
-export async function GET() {
-  const { result: results, error } = await withError(storage.readResults());
+export async function GET(request: NextRequest) {
+  const { searchParams } = new URL(request.url);
+  const pagination = parseFromRequest(searchParams);
+  const project = searchParams.get('project') ?? '';
+
+  const { result, error } = await withError(storage.readResults({ pagination, project }));
 
   if (error) {
     return new Response(error.message, { status: 400 });
   }
 
-  return Response.json(results?.sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()));
+  return Response.json(result);
 }

--- a/app/api/result/projects/route.ts
+++ b/app/api/result/projects/route.ts
@@ -1,0 +1,12 @@
+import { storage } from '@/app/lib/storage';
+import { withError } from '@/app/lib/withError';
+
+export async function GET() {
+  const { result: projects, error } = await withError(storage.getResultsProjects());
+
+  if (error) {
+    return new Response(error.message, { status: 400 });
+  }
+
+  return Response.json(projects);
+}

--- a/app/api/result/projects/route.ts
+++ b/app/api/result/projects/route.ts
@@ -1,6 +1,8 @@
 import { storage } from '@/app/lib/storage';
 import { withError } from '@/app/lib/withError';
 
+export const dynamic = 'force-dynamic'; // defaults to auto
+
 export async function GET() {
   const { result: projects, error } = await withError(storage.getResultsProjects());
 

--- a/app/components/generate-report-button.tsx
+++ b/app/components/generate-report-button.tsx
@@ -25,7 +25,11 @@ interface DeleteProjectButtonProps {
   onGeneratedReport?: () => void;
 }
 
-export default function GenerateReportButton({ results, projects, onGeneratedReport }: DeleteProjectButtonProps) {
+export default function GenerateReportButton({
+  results,
+  projects,
+  onGeneratedReport,
+}: Readonly<DeleteProjectButtonProps>) {
   const { mutate: generateReport, isLoading, error } = useMutation('/api/report/generate', { method: 'POST' });
 
   const [projectName, setProjectName] = useState('');
@@ -61,6 +65,7 @@ export default function GenerateReportButton({ results, projects, onGeneratedRep
                 <Autocomplete
                   allowsCustomValue
                   defaultInputValue={projects.at(0) ?? ''}
+                  isDisabled={isLoading}
                   items={projects.map((project) => ({ label: project, value: project }))}
                   label="Project name"
                   placeholder="leave empty if not required"

--- a/app/components/project-select.tsx
+++ b/app/components/project-select.tsx
@@ -10,10 +10,17 @@ import ErrorMessage from './error-message';
 interface ProjectSelectProps {
   onSelect: (project: string) => void;
   refreshId?: string;
+  entity: 'result' | 'report';
 }
 
-export default function ProjectSelect({ refreshId, onSelect }: Readonly<ProjectSelectProps>) {
-  const { data: projects, error, isLoading } = useQuery<string[]>('/api/project/list', { dependencies: [refreshId] });
+export default function ProjectSelect({ refreshId, onSelect, entity }: Readonly<ProjectSelectProps>) {
+  const {
+    data: projects,
+    error,
+    isLoading,
+  } = useQuery<string[]>(`/api/${entity}/projects`, {
+    dependencies: [refreshId],
+  });
 
   const items = [defaultProjectName, ...(projects ?? [])];
 
@@ -36,12 +43,11 @@ export default function ProjectSelect({ refreshId, onSelect }: Readonly<ProjectS
       {error && <ErrorMessage message={error.message ?? ''} />}
       <Select
         disallowEmptySelection
-        className="pt-1 max-w-[30%]"
+        className="pt-1 w-full"
         defaultSelectedKeys={[defaultProjectName]}
         isDisabled={items.length <= 1}
         isLoading={isLoading}
         label="project"
-        size="lg"
         onSelectionChange={onChange}
       >
         {items.map((project) => (

--- a/app/components/report-trends.tsx
+++ b/app/components/report-trends.tsx
@@ -30,7 +30,9 @@ export default function ReportTrends() {
       <div className="flex flex-row justify-between">
         <h1 className={title()}>Trends</h1>
         {isLoading && <Spinner />}
-        <ProjectSelect onSelect={onProjectChange} />
+        <div className="min-w-[30%]">
+          <ProjectSelect entity="report" onSelect={onProjectChange} />
+        </div>
       </div>
       {error && <ErrorMessage message={error.message} />}
       {!!reports?.length && <TrendChart reportHistory={reports} />}

--- a/app/components/reports.tsx
+++ b/app/components/reports.tsx
@@ -1,12 +1,4 @@
 'use client';
-
-import { useState } from 'react';
-import { v4 as uuidv4 } from 'uuid';
-
-import { defaultProjectName } from '../lib/constants';
-
-import ProjectSelect from './project-select';
-
 import ReportsTable from '@/app/components/reports-table';
 import { title } from '@/app/components/primitives';
 
@@ -15,22 +7,13 @@ interface ReportsProps {
 }
 
 export default function Reports({ onChange }: ReportsProps) {
-  const [refreshId, setRefreshId] = useState<string>(uuidv4());
-  const [project, setProject] = useState(defaultProjectName);
-
-  const updateView = () => {
-    onChange?.();
-    setRefreshId(uuidv4());
-  };
-
   return (
     <>
       <div className="flex flex-row justify-between">
         <h1 className={title()}>Reports</h1>
-        <ProjectSelect refreshId={refreshId} onSelect={setProject} />
       </div>
       <br />
-      <ReportsTable project={project} onChange={updateView} />
+      <ReportsTable onChange={onChange} />
     </>
   );
 }

--- a/app/components/results-table.tsx
+++ b/app/components/results-table.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import {
   Table,
   TableHeader,
@@ -11,18 +11,17 @@ import {
   Chip,
   type Selection,
   Spinner,
-  Autocomplete,
-  AutocompleteItem,
+  Pagination,
 } from '@nextui-org/react';
 
-import { SearchIcon } from './icons';
-
+import { withQueryParams } from '@/app/lib/network';
+import { defaultProjectName } from '@/app/lib/constants';
+import TablePaginationOptions from '@/app/components/table-pagination-options';
 import useQuery from '@/app/hooks/useQuery';
 import ErrorMessage from '@/app/components/error-message';
 import FormattedDate from '@/app/components/date-format';
-import { type Result } from '@/app/lib/storage';
+import { ReadResultsOutput, type Result } from '@/app/lib/storage';
 import DeleteResultsButton from '@/app/components/delete-results-button';
-import { getUniqueProjectsList } from '@/app/lib/storage/format';
 
 const columns = [
   { name: 'ID', uid: 'resultID' },
@@ -37,37 +36,62 @@ const getTags = (item: Result) => {
 };
 
 interface ResultsTableProps {
-  refreshId: string;
   selected?: string[];
   onSelect?: (results: Result[]) => void;
   onDeleted?: () => void;
 }
 
-export default function ResultsTable({ refreshId, onSelect, onDeleted, selected }: ResultsTableProps) {
-  const { data: results, error, isLoading, refetch } = useQuery<Result[]>('/api/result/list');
-
-  const projects = getUniqueProjectsList(results ?? []);
-
-  const [projectFilter, setProjectFilter] = useState('');
-
-  const filteredResults = React.useMemo(() => {
-    if (projectFilter) {
-      return results?.filter((r) => r.project?.includes(projectFilter));
-    }
-
-    return results;
-  }, [results, projectFilter]);
+export default function ResultsTable({ onSelect, onDeleted, selected }: ResultsTableProps) {
+  const resultListEndpoint = '/api/result/list';
+  const [project, setProject] = useState(defaultProjectName);
+  const [page, setPage] = useState(1);
+  const [rowsPerPage, setRowsPerPage] = useState(20);
+  const getQueryParams = () => ({
+    limit: rowsPerPage.toString(),
+    offset: ((page - 1) * rowsPerPage).toString(),
+    project,
+  });
+  const {
+    data: resultsResponse,
+    error,
+    isLoading,
+    refetch,
+  } = useQuery<ReadResultsOutput>(withQueryParams(resultListEndpoint, getQueryParams()));
 
   useEffect(() => {
-    if (!isLoading) {
-      refetch();
+    if (isLoading) {
+      return;
     }
-  }, [refreshId]);
+    refetch({
+      path: withQueryParams(resultListEndpoint, getQueryParams()),
+    });
+  }, [rowsPerPage, project, page]);
+
+  const { results, total } = resultsResponse ?? {};
 
   const shouldRefetch = () => {
-    refetch();
     onDeleted?.();
+    refetch();
   };
+
+  const onPageChange = useCallback(
+    (page: number) => {
+      setPage(page);
+    },
+    [page, rowsPerPage],
+  );
+
+  const onProjectChange = useCallback(
+    (project: string) => {
+      setProject(project);
+      setPage(1);
+    },
+    [page, rowsPerPage],
+  );
+
+  const pages = React.useMemo(() => {
+    return total ? Math.ceil(total / rowsPerPage) : 0;
+  }, [project, total, rowsPerPage]);
 
   const onChangeSelect = (keys: Selection) => {
     if (keys === 'all') {
@@ -90,23 +114,36 @@ export default function ResultsTable({ refreshId, onSelect, onDeleted, selected 
     <ErrorMessage message={error.message} />
   ) : (
     <>
-      <Autocomplete
-        allowsCustomValue
-        aria-label="filter by project name"
-        className="pt-1 mb-5 max-w-[30%]"
-        isDisabled={!projects.length}
-        placeholder="filter by project name"
-        size="lg"
-        startContent={<SearchIcon />}
-        value={projectFilter}
-        onInputChange={(value) => setProjectFilter(value)}
-        onSelectionChange={(value) => setProjectFilter(value?.toString() ?? '')}
+      <TablePaginationOptions
+        entity="result"
+        rowPerPageOptions={[20, 40, 80, 120]}
+        rowsPerPage={rowsPerPage}
+        setPage={setPage}
+        setRowsPerPage={setRowsPerPage}
+        total={total}
+        onProjectChange={onProjectChange}
+      />
+      <Table
+        aria-label="Results"
+        bottomContent={
+          pages > 1 ? (
+            <div className="flex w-full justify-center">
+              <Pagination
+                isCompact
+                showControls
+                showShadow
+                color="primary"
+                page={page}
+                total={pages}
+                onChange={onPageChange}
+              />
+            </div>
+          ) : null
+        }
+        selectedKeys={selected}
+        selectionMode="multiple"
+        onSelectionChange={onChangeSelect}
       >
-        {projects.map((project) => (
-          <AutocompleteItem key={project}>{project}</AutocompleteItem>
-        ))}
-      </Autocomplete>
-      <Table aria-label="Results" selectedKeys={selected} selectionMode="multiple" onSelectionChange={onChangeSelect}>
         <TableHeader columns={columns}>
           {(column) => (
             <TableColumn key={column.uid} align={column.uid === 'actions' ? 'center' : 'start'}>
@@ -114,12 +151,7 @@ export default function ResultsTable({ refreshId, onSelect, onDeleted, selected 
             </TableColumn>
           )}
         </TableHeader>
-        <TableBody
-          emptyContent="No results."
-          isLoading={isLoading}
-          items={filteredResults ?? []}
-          loadingContent={<Spinner />}
-        >
+        <TableBody emptyContent="No results." isLoading={isLoading} items={results ?? []} loadingContent={<Spinner />}>
           {(item) => (
             <TableRow key={item.resultID}>
               <TableCell className="w-1/3">{item.resultID}</TableCell>

--- a/app/components/results.tsx
+++ b/app/components/results.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { useState } from 'react';
-import { v4 as uuidv4 } from 'uuid';
 
 import { type Result } from '@/app/lib/storage';
 import ResultsTable from '@/app/components/results-table';
@@ -14,9 +13,8 @@ interface ResultsProps {
   onChange: () => void;
 }
 
-export default function Results({ onChange }: ResultsProps) {
+export default function Results({ onChange }: Readonly<ResultsProps>) {
   const [selectedResults, setSelectedResults] = useState<Result[]>([]);
-  const [refreshId, setRefreshId] = useState<string>(uuidv4());
 
   const selectedResultIds = selectedResults.map((r) => r.resultID);
 
@@ -27,11 +25,6 @@ export default function Results({ onChange }: ResultsProps) {
     onChange?.();
   };
 
-  const onDelete = () => {
-    onListUpdate();
-    setRefreshId(uuidv4());
-  };
-
   return (
     <>
       <div className="flex w-full">
@@ -40,16 +33,11 @@ export default function Results({ onChange }: ResultsProps) {
         </div>
         <div className="flex gap-2 w-2/3 flex-wrap justify-end mr-7">
           <GenerateReportButton projects={projects} results={selectedResults} onGeneratedReport={onListUpdate} />
-          <DeleteResultsButton resultIds={selectedResultIds} onDeletedResult={onDelete} />
+          <DeleteResultsButton resultIds={selectedResultIds} onDeletedResult={onListUpdate} />
         </div>
       </div>
       <br />
-      <ResultsTable
-        refreshId={refreshId}
-        selected={selectedResultIds}
-        onDeleted={onDelete}
-        onSelect={setSelectedResults}
-      />
+      <ResultsTable selected={selectedResultIds} onDeleted={onListUpdate} onSelect={setSelectedResults} />
     </>
   );
 }

--- a/app/components/table-pagination-options.tsx
+++ b/app/components/table-pagination-options.tsx
@@ -1,0 +1,64 @@
+'use client';
+
+import React, { ChangeEvent, useCallback } from 'react';
+import { Select, SelectItem } from '@nextui-org/react';
+
+import ProjectSelect from '@/app/components/project-select';
+
+interface TablePaginationRowProps {
+  total?: number;
+  rowsPerPage: number;
+  setRowsPerPage: (rows: number) => void;
+  setPage: (page: number) => void;
+  onProjectChange: (project: string) => void;
+  rowPerPageOptions?: number[];
+  entity: 'report' | 'result';
+}
+
+const defaultRowPerPageOptions = [10, 20, 40];
+
+export default function TablePaginationOptions({
+  total,
+  rowsPerPage,
+  entity,
+  rowPerPageOptions,
+  setRowsPerPage,
+  setPage,
+  onProjectChange,
+}: TablePaginationRowProps) {
+  const rowPerPageItems = rowPerPageOptions ?? defaultRowPerPageOptions;
+
+  const onRowsPerPageChange = useCallback(
+    (e: ChangeEvent<HTMLSelectElement>) => {
+      const rows = Number(e.target.value);
+
+      setRowsPerPage(rows);
+      setPage(1);
+    },
+    [rowsPerPage],
+  );
+
+  return (
+    <div className="flex justify-between items-center mb-3">
+      <span className="text-default-400 text-small">Total {total ?? 0}</span>
+      <div className="flex flex-row min-w-[60%] justify-end gap-3">
+        <div className="min-w-[50%]">
+          <ProjectSelect entity={entity} onSelect={onProjectChange} />
+        </div>
+        <Select
+          disallowEmptySelection
+          className="w-36 min-w-36 p-1"
+          label="rows per page"
+          selectedKeys={[rowsPerPage.toString()]}
+          onChange={onRowsPerPageChange}
+        >
+          {rowPerPageItems.map((item) => (
+            <SelectItem key={item} textValue={item.toString()} value={item}>
+              {item}
+            </SelectItem>
+          ))}
+        </Select>
+      </div>
+    </div>
+  );
+}

--- a/app/hooks/useMutation.ts
+++ b/app/hooks/useMutation.ts
@@ -11,7 +11,7 @@ const useMutation = (url: string, options: RequestInit) => {
   const apiToken = session?.data?.user?.apiToken;
 
   const mutate = useCallback(
-    async (body?: unknown) => {
+    async (body?: unknown, opts?: { path: string }) => {
       setLoading(true);
       setError(null);
 
@@ -22,7 +22,7 @@ const useMutation = (url: string, options: RequestInit) => {
             }
           : undefined;
 
-        const response = await fetch(url, {
+        const response = await fetch(opts?.path ?? url, {
           headers,
           body: body ? JSON.stringify(body) : undefined,
           method: options?.method ?? 'GET',

--- a/app/lib/network.ts
+++ b/app/lib/network.ts
@@ -1,0 +1,18 @@
+import { defaultProjectName } from './constants';
+
+export class CommonResponseFactory {
+  static buildUnauthorizedResponse(): Response {
+    return new Response('Unauthorized', { status: 401 });
+  }
+}
+
+export const withQueryParams = (url: string, params: Record<string, string>): string => {
+  if (params?.project === defaultProjectName) {
+    delete params.project;
+  }
+
+  const searchParams = new URLSearchParams(params);
+  const stringified = searchParams.toString();
+
+  return `${url}?${stringified}`;
+};

--- a/app/lib/response.ts
+++ b/app/lib/response.ts
@@ -1,5 +1,0 @@
-export class CommonResponseFactory {
-  static buildUnauthorizedResponse(): Response {
-    return new Response('Unauthorized', { status: 401 });
-  }
-}

--- a/app/lib/sort.ts
+++ b/app/lib/sort.ts
@@ -1,5 +1,0 @@
-import { type Report } from '@/app/lib/storage';
-
-export const sortReportsByCreatedDate = (reports: Report[]) => {
-  return reports.sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime());
-};

--- a/app/lib/storage/batch.ts
+++ b/app/lib/storage/batch.ts
@@ -1,0 +1,18 @@
+export async function processBatch<T, R>(
+  ctx: unknown,
+  items: T[],
+  batchSize: number,
+  asyncAction: (item: T) => Promise<R>,
+): Promise<R[]> {
+  const results: R[] = [];
+
+  for (let i = 0; i < items.length; i += batchSize) {
+    const batch = items.slice(i, i + batchSize);
+
+    const batchResults = await Promise.all(batch.map(asyncAction.bind(ctx)));
+
+    results.push(...batchResults);
+  }
+
+  return results;
+}

--- a/app/lib/storage/fs.ts
+++ b/app/lib/storage/fs.ts
@@ -1,16 +1,27 @@
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import { randomUUID } from 'node:crypto';
+import { type Dirent, type Stats } from 'node:fs';
 
 import getFolderSize from 'get-folder-size';
 
 import { bytesToString, getUniqueProjectsList } from './format';
 import { DATA_FOLDER, REPORTS_FOLDER, REPORTS_PATH, RESULTS_FOLDER, TMP_FOLDER } from './constants';
+import { processBatch } from './batch';
+import { handlePagination } from './pagination';
 
 import { generatePlaywrightReport } from '@/app/lib/pw';
 import { withError } from '@/app/lib/withError';
 import { serveReportRoute } from '@/app/lib/constants';
-import { type Storage, type Report, type Result, type ServerDataInfo, type ResultDetails } from '@/app/lib/storage';
+import {
+  type Storage,
+  type Result,
+  type ServerDataInfo,
+  type ResultDetails,
+  ReadReportsOutput,
+  ReadReportsInput,
+  ReadResultsInput,
+} from '@/app/lib/storage';
 
 async function createDirectoriesIfMissing() {
   async function createDirectory(dir: string) {
@@ -36,16 +47,16 @@ const getFolderSizeInMb = async (dir: string) => {
 export async function getServerDataInfo(): Promise<ServerDataInfo> {
   await createDirectoriesIfMissing();
   const dataFolderSizeinMB = await getFolderSizeInMb(DATA_FOLDER);
-  const results = await readResults();
+  const resultsCount = await getResultsCount();
   const resultsFolderSizeinMB = await getFolderSizeInMb(RESULTS_FOLDER);
-  const reports = await readReports();
+  const { total: reportsCount } = await readReports();
   const reportsFolderSizeinMB = await getFolderSizeInMb(REPORTS_FOLDER);
 
   return {
     dataFolderSizeinMB,
-    numOfResults: results.length,
+    numOfResults: resultsCount,
     resultsFolderSizeinMB,
-    numOfReports: reports.length,
+    numOfReports: reportsCount,
     reportsFolderSizeinMB,
   };
 }
@@ -56,48 +67,101 @@ export async function readFile(targetPath: string, contentType: string | null) {
   });
 }
 
-export async function readResults() {
+async function getResultsCount() {
+  const files = await fs.readdir(RESULTS_FOLDER);
+
+  return Math.round(files.length / 2);
+}
+
+export async function readResults(input?: ReadResultsInput) {
   await createDirectoriesIfMissing();
   const files = await fs.readdir(RESULTS_FOLDER);
-  const jsonFiles = files.filter((file) => path.extname(file) === '.json');
+
+  const stats = await processBatch<string, Stats & { filePath: string }>({}, files, 20, async (file) => {
+    const filePath = path.join(RESULTS_FOLDER, file);
+
+    const stat = await fs.stat(filePath);
+
+    return Object.assign(stat, { filePath });
+  });
+
+  const jsonFiles = stats
+    .filter((stat) => stat.isFile() && path.extname(stat.filePath) === '.json')
+    .sort((a, b) => b.birthtimeMs - a.birthtimeMs)
+    .map((stat) => stat.filePath);
 
   const fileContents: Result[] = await Promise.all(
-    jsonFiles.map(async (file) => {
-      const filePath = path.join(RESULTS_FOLDER, file);
+    jsonFiles.map(async (filePath) => {
       const content = await fs.readFile(filePath, 'utf-8');
 
       return JSON.parse(content);
     }),
   );
 
-  return fileContents;
+  const resultsByProject = fileContents.filter((result) =>
+    input?.project ? result.project === input.project : result,
+  );
+
+  const paginatedResults = handlePagination(resultsByProject, input?.pagination);
+
+  return {
+    results: paginatedResults,
+    total: resultsByProject.length,
+  };
 }
 
-export async function readReports(): Promise<Report[]> {
+export async function readReports(input?: ReadReportsInput): Promise<ReadReportsOutput> {
   await createDirectoriesIfMissing();
   const entries = await fs.readdir(REPORTS_FOLDER, { withFileTypes: true, recursive: true });
 
-  const reportFiles = entries.filter(
-    (entry) => !entry.isDirectory() && entry.name === 'index.html' && !entry.path.endsWith('trace'),
+  const reportEntries = entries
+    .filter((entry) => !entry.isDirectory() && entry.name === 'index.html' && !entry.path.endsWith('trace'))
+    .filter((entry) => (input?.ids ? input.ids.some((id) => entry.path.includes(id)) : entry))
+    .filter((entry) => (input?.project ? entry.path.includes(input.project) : entry));
+
+  const stats = await processBatch<Dirent, Stats & { filePath: string; createdAt: Date }>(
+    {},
+    reportEntries,
+    20,
+    async (file) => {
+      const stat = await fs.stat(file.path);
+
+      return Object.assign(stat, { filePath: file.path, createdAt: stat.birthtime });
+    },
   );
 
-  return await Promise.all(
-    reportFiles.map(async (file) => {
-      const id = path.basename(file.path);
-      const parentDir = path.basename(path.dirname(file.path));
+  const reportFiles = stats.sort((a, b) => b.birthtimeMs - a.birthtimeMs);
+
+  const reportsWithProject = reportFiles
+    .map((file) => {
+      const id = path.basename(file.filePath);
+      const parentDir = path.basename(path.dirname(file.filePath));
 
       const projectName = parentDir === REPORTS_PATH ? '' : parentDir;
 
-      const stat = await fs.stat(file.path);
+      return Object.assign(file, { id, project: projectName });
+    })
+    .filter((report) => (input?.project ? input.project === report.project : report));
+
+  const paginatedFiles = handlePagination(reportsWithProject, input?.pagination);
+
+  const reports = await Promise.all(
+    paginatedFiles.map(async (file) => {
+      const id = path.basename(file.filePath);
+      const parentDir = path.basename(path.dirname(file.filePath));
+
+      const projectName = parentDir === REPORTS_PATH ? '' : parentDir;
 
       return {
         reportID: id,
         project: projectName,
-        createdAt: stat.birthtime,
+        createdAt: file.birthtime,
         reportUrl: `${serveReportRoute}/${projectName ? encodeURIComponent(projectName) : ''}/${id}/index.html`,
       };
     }),
   );
+
+  return { reports, total: reportsWithProject.length };
 }
 
 export async function deleteResults(resultsIds: string[]) {
@@ -111,7 +175,7 @@ export async function deleteResult(resultId: string) {
 }
 
 export async function deleteReports(reportsIds: string[]) {
-  const reports = await readReports();
+  const { reports } = await readReports({ ids: reportsIds });
 
   const paths = reportsIds
     .map((id) => reports.find((report) => report.reportID === id))
@@ -164,10 +228,16 @@ export async function generateReport(resultsIds: string[], project?: string) {
   return reportId;
 }
 
-export async function getProjects(): Promise<string[]> {
-  const reports = await readReports();
+export async function getReportsProjects(): Promise<string[]> {
+  const { reports } = await readReports();
 
   return getUniqueProjectsList(reports);
+}
+
+export async function getResultsProjects(): Promise<string[]> {
+  const { results } = await readResults();
+
+  return getUniqueProjectsList(results);
 }
 
 export async function moveReport(oldPath: string, newPath: string): Promise<void> {
@@ -180,7 +250,6 @@ export async function moveReport(oldPath: string, newPath: string): Promise<void
 }
 
 export const FS: Storage = {
-  getFolderSizeInMb,
   getServerDataInfo,
   readFile,
   readResults,
@@ -189,6 +258,7 @@ export const FS: Storage = {
   deleteReports,
   saveResult,
   generateReport,
-  getProjects,
+  getReportsProjects,
+  getResultsProjects,
   moveReport,
 };

--- a/app/lib/storage/pagination.ts
+++ b/app/lib/storage/pagination.ts
@@ -1,0 +1,22 @@
+export interface Pagination {
+  limit: number;
+  offset: number;
+}
+
+export const handlePagination = <T>(items: T[], pagination?: Pagination): T[] => {
+  if (!pagination) {
+    return items;
+  }
+
+  return items.slice(pagination.offset, pagination.offset + pagination.limit);
+};
+
+export const parseFromRequest = (searchParams: URLSearchParams): Pagination => {
+  const limitQuery = searchParams.get('limit') ?? '';
+  const offsetQuery = searchParams.get('offset') ?? '';
+
+  const limit = limitQuery ? parseInt(limitQuery, 10) : 20;
+  const offset = offsetQuery ? parseInt(offsetQuery, 10) : 0;
+
+  return { limit, offset };
+};

--- a/app/lib/storage/s3.ts
+++ b/app/lib/storage/s3.ts
@@ -310,10 +310,6 @@ export class S3 implements Storage {
           reportUrl: `${serveReportRoute}/${projectName ? encodeURIComponent(projectName) : ''}/${id}/index.html`,
         };
 
-        if (shouldFilterByID) {
-          reportsStream.destroy();
-        }
-
         if (noFilters || shouldFilterByProject || shouldFilterByID) {
           reports.push(report);
         }
@@ -327,8 +323,6 @@ export class S3 implements Storage {
         const getTimestamp = (date?: Date) => date?.getTime() ?? 0;
 
         reports.sort((a, b) => getTimestamp(b.createdAt) - getTimestamp(a.createdAt));
-
-        console.log(JSON.stringify(reports, null, 2));
 
         const currentReports = handlePagination<Report>(reports, input?.pagination);
 

--- a/app/lib/storage/s3.ts
+++ b/app/lib/storage/s3.ts
@@ -152,7 +152,7 @@ export class S3 implements Storage {
           resultCount += 1;
         }
 
-        if (obj.name?.endsWith('index.html') && !obj.name.includes('trace')) {
+        if (obj.name?.endsWith('index.html') && !obj.name.includes('/trace/index.html')) {
           indexCount += 1;
         }
 

--- a/app/lib/storage/types.ts
+++ b/app/lib/storage/types.ts
@@ -1,12 +1,13 @@
+import { type Pagination } from './pagination';
+
 import { type UUID } from '@/app/types';
 import { type ReportInfo, type ReportTest } from '@/app/lib/parser/types';
 
 export interface Storage {
   getServerDataInfo: () => Promise<ServerDataInfo>;
-  getFolderSizeInMb: (dir: string) => Promise<string>;
   readFile: (targetPath: string, contentType: string | null) => Promise<string | Buffer>;
-  readResults: () => Promise<Result[]>;
-  readReports: () => Promise<Report[]>;
+  readResults: (input: ReadResultsInput) => Promise<ReadResultsOutput>;
+  readReports: (input?: ReadReportsInput) => Promise<ReadReportsOutput>;
   deleteResults: (resultIDs: string[]) => Promise<void>;
   deleteReports: (reportIDs: string[]) => Promise<void>;
   saveResult: (
@@ -17,8 +18,30 @@ export interface Storage {
     createdAt: string;
   }>;
   generateReport: (resultsIds: string[], project?: string) => Promise<UUID>;
-  getProjects: () => Promise<string[]>;
+  getReportsProjects: () => Promise<string[]>;
+  getResultsProjects: () => Promise<string[]>;
   moveReport: (oldPath: string, newPath: string) => Promise<void>;
+}
+
+export interface ReadResultsInput {
+  pagination?: Pagination;
+  project?: string;
+}
+
+export interface ReadResultsOutput {
+  results: Result[];
+  total: number;
+}
+
+export interface ReadReportsInput {
+  pagination?: Pagination;
+  project?: string;
+  ids?: string[];
+}
+
+export interface ReadReportsOutput {
+  reports: Report[];
+  total: number;
 }
 
 // For custom user fields

--- a/app/report/[id]/page.tsx
+++ b/app/report/[id]/page.tsx
@@ -22,15 +22,7 @@ function ReportDetail({ params }: Readonly<ReportDetailProps>) {
     data: report,
     isLoading: isReportLoading,
     error: reportError,
-  } = useQuery<ReportHistory>(`/api/report/${params.id}`);
-
-  const {
-    data: history,
-    isLoading: isHistoryLoading,
-    error: historyError,
-  } = useQuery<ReportHistory[]>(`/api/report/trend?limit=10&project=${report?.project ?? ''}`, {
-    callback: `/report/${params.id}`,
-  });
+  } = useQuery<ReportHistory>(`/api/report/${params.id}`, { callback: `/report/${params.id}` });
 
   if (session.status === 'loading') {
     return (
@@ -48,15 +40,7 @@ function ReportDetail({ params }: Readonly<ReportDetailProps>) {
     );
   }
 
-  if (isHistoryLoading) {
-    return (
-      <div>
-        Loading test history... <Spinner />
-      </div>
-    );
-  }
-
-  const error = reportError || historyError;
+  const error = reportError;
 
   if (error) {
     return <p>Error: {error.message}</p>;
@@ -79,9 +63,7 @@ function ReportDetail({ params }: Readonly<ReportDetailProps>) {
             <Button color="primary">Open report</Button>
           </Link>
         </div>
-        <div className="md:w-3/4 max-w-full">
-          <FileList history={history ?? []} report={report} />
-        </div>
+        <div className="md:w-3/4 max-w-full">{report && <FileList report={report} />}</div>
       </div>
     </>
   );

--- a/app/report/[id]/page.tsx
+++ b/app/report/[id]/page.tsx
@@ -28,7 +28,9 @@ function ReportDetail({ params }: Readonly<ReportDetailProps>) {
     data: history,
     isLoading: isHistoryLoading,
     error: historyError,
-  } = useQuery<ReportHistory[]>('/api/report/trend?limit=10', { callback: `/report/${params.id}` });
+  } = useQuery<ReportHistory[]>(`/api/report/trend?limit=10&project=${report?.project ?? ''}`, {
+    callback: `/report/${params.id}`,
+  });
 
   if (session.status === 'loading') {
     return (

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,6 +1,6 @@
 import { NextResponse, type NextRequest } from 'next/server';
 
-import { CommonResponseFactory } from '@/app/lib/response';
+import { CommonResponseFactory } from '@/app/lib/network';
 import { isAuthorized } from '@/app/lib/auth';
 import { env } from '@/app/config/env';
 

--- a/readme.md
+++ b/readme.md
@@ -78,20 +78,23 @@ curl --location --request DELETE 'http://localhost:3000/api/report/delete' \
 Response example:
 
 ```json
-[
-  {
-    "reportID": "8e9af87d-1d10-4729-aefd-3e92ee64d06c",
-    "createdAt": "2024-05-06T16:52:45.017Z",
-    "project": "regression",
-    "reportUrl": "/api/serve/regression/8e9af87d-1d10-4729-aefd-3e92ee64d06c/index.html"
-  },
-  {
-    "reportID": "8fe427ed-783c-4fb9-aacc-ba6fbc5f5667",
-    "createdAt": "2024-05-06T16:59:38.814Z",
-    "project": "smoke",
-    "reportUrl": "/api/serve/smoke/8fe427ed-783c-4fb9-aacc-ba6fbc5f5667/index.html"
-  }
-]
+{
+  "reports": [
+    {
+      "reportID": "8e9af87d-1d10-4729-aefd-3e92ee64d06c",
+      "createdAt": "2024-05-06T16:52:45.017Z",
+      "project": "regression",
+      "reportUrl": "/api/serve/regression/8e9af87d-1d10-4729-aefd-3e92ee64d06c/index.html"
+    },
+    {
+      "reportID": "8fe427ed-783c-4fb9-aacc-ba6fbc5f5667",
+      "createdAt": "2024-05-06T16:59:38.814Z",
+      "project": "smoke",
+      "reportUrl": "/api/serve/smoke/8fe427ed-783c-4fb9-aacc-ba6fbc5f5667/index.html"
+    }
+  ],
+  "total": 2
+}
 ```
 
 ## `/api/report/delete` (DELETE):
@@ -156,15 +159,18 @@ curl --location 'http://localhost:3000/api/result/list'
 Response will contain array of results:
 
 ```json
-[
-  {
-    "resultID": "a7beb04b-f190-4fbb-bebd-58b2c776e6c3",
-    "createdAt": "2024-05-06T16:40:33.021Z",
-    "project": "regression",
-    "testRunName": "regression-run-v1.10",
-    "reporter": "okhotemskyi"
-  }
-]
+{
+  "results": [
+    {
+      "resultID": "a7beb04b-f190-4fbb-bebd-58b2c776e6c3",
+      "createdAt": "2024-05-06T16:40:33.021Z",
+      "project": "regression",
+      "testRunName": "regression-run-v1.10",
+      "reporter": "okhotemskyi"
+    }
+  ],
+  "total": 1
+}
 ```
 
 ## `/api/result/upload` (POST):


### PR DESCRIPTION
## Demo

### S3:
URL: https://unicorn.shelex.dev/
Api Token: 12345

### FS
URL: https://unicorn-fs.shelex.dev/
Api Token: 12345

## Added
- query parameters for pagination and project filter on route level
- handling for pagination and project filter in storage implementations
- handle results and reports projects separately
- ui handler for proper pagination and filters for results and reports tables
- use batch for reading results with fs
- fetch report test history for reports from specific project
- optimisations for fetching results and reports

## Changed
- `/api/report/list` 
     ```diff
     - []
     + { reports: [], total: 0 }
     ```
- `/api/result/list` 
     ```diff
     - []
     + { results: [], total: 0 }
     ```

## Fix
- disable project name input when generating new report