### PR TITLE
fix: add validation for uploaded results, handle errors

### DIFF
--- a/app/api/result/upload/route.ts
+++ b/app/api/result/upload/route.ts
@@ -1,3 +1,4 @@
+import { isBufferZipResult } from '@/app/lib/parser/validate';
 import { type ResultDetails, storage } from '@/app/lib/storage';
 import { withError } from '@/app/lib/withError';
 
@@ -35,6 +36,12 @@ export async function PUT(request: Request) {
     }
     // String values for now
     resultDetails[key] = value.toString();
+  }
+
+  const { error: bufferValidationError } = await withError(isBufferZipResult(buffer));
+
+  if (bufferValidationError) {
+    return Response.json({ error: `invalid result file: ${bufferValidationError.message}` }, { status: 400 });
   }
 
   const { result: savedResult, error } = await withError(storage.saveResult(buffer, resultDetails));

--- a/app/lib/parser/validate.ts
+++ b/app/lib/parser/validate.ts
@@ -1,0 +1,27 @@
+import JSZip from 'jszip';
+
+import { withError } from '@/app/lib/withError';
+
+export const isBufferZipResult = async (buffer: Buffer) => {
+  const { result: zip, error } = await withError(JSZip.loadAsync(buffer));
+
+  if (error) {
+    throw Error(`failed to load zip file: ${error.message}`);
+  }
+
+  if (!zip) {
+    throw Error('parsed report data is empty');
+  }
+
+  const resourcesFolder = zip.folder('resources');
+
+  if (!resourcesFolder) {
+    throw Error('no resources found in the zip');
+  }
+
+  const file = zip.file('report.jsonl');
+
+  if (!file) {
+    throw Error('no report.jsonl file found in the zip');
+  }
+};

--- a/app/lib/pw.ts
+++ b/app/lib/pw.ts
@@ -22,7 +22,7 @@ export const generatePlaywrightReport = async (
 
   console.log(`[pw] merging reports from ${TMP_FOLDER}`);
 
-  const { error } = await withError(
+  const { result, error } = await withError(
     execAsync(`npx playwright merge-reports --reporter html ${TMP_FOLDER}`, {
       env: {
         ...process.env,
@@ -33,8 +33,8 @@ export const generatePlaywrightReport = async (
     }),
   );
 
-  if (error) {
-    console.error(JSON.stringify(error, null, 4));
+  if (error ?? result?.stderr) {
+    console.error(error ? JSON.stringify(error, null, 4) : result?.stderr);
   }
 
   return {


### PR DESCRIPTION
## Rationale

Currently it is impossible to debug the report generation as few errors were handled during uploading.

## Added
- validate result file buffer which should be a zip file with pw-specific folder and file
- add result file buffer validation to `/api/result/upload` endpoint
- add more error handling to report index.html parser
- show any `stderr` from playwright report generation
- add more error handling to fs storage saving results