### PR TITLE
fix: handle .temp per specific report generation, address #37

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 
 # data
 /data
+.tmp
 
 # dependencies
 /node_modules

--- a/app/lib/pw.ts
+++ b/app/lib/pw.ts
@@ -1,6 +1,6 @@
 import { exec } from 'node:child_process';
 import util from 'node:util';
-import { randomUUID, type UUID } from 'node:crypto';
+import { type UUID } from 'node:crypto';
 import path from 'node:path';
 
 import { withError } from './withError';
@@ -9,21 +9,21 @@ import { REPORTS_FOLDER, TMP_FOLDER } from './storage/constants';
 const execAsync = util.promisify(exec);
 
 export const generatePlaywrightReport = async (
+  reportId: UUID,
   projectName?: string,
-): Promise<{ reportId: UUID; reportPath: string }> => {
-  console.log(`[pw] generating Playwright report`);
-  const reportId = randomUUID();
-
-  console.log(`[pw] report ID: ${reportId}`);
+): Promise<{ reportPath: string }> => {
+  console.log(`[pw] generating Playwright report ${reportId}`);
 
   const reportPath = path.join(REPORTS_FOLDER, projectName ?? '', reportId);
 
   console.log(`[pw] report path: ${reportPath}`);
 
-  console.log(`[pw] merging reports from ${TMP_FOLDER}`);
+  const tempFolder = path.join(TMP_FOLDER, reportId);
+
+  console.log(`[pw] merging reports from ${tempFolder}`);
 
   const { result, error } = await withError(
-    execAsync(`npx playwright merge-reports --reporter html ${TMP_FOLDER}`, {
+    execAsync(`npx playwright merge-reports --reporter html ${tempFolder}`, {
       env: {
         ...process.env,
         // Avoid opening the report on server
@@ -38,7 +38,6 @@ export const generatePlaywrightReport = async (
   }
 
   return {
-    reportId,
     reportPath,
   };
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "playwright-reports-server",
-  "version": "3.1.1",
+  "version": "3.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "playwright-reports-server",
-      "version": "3.1.1",
+      "version": "3.2.0",
       "dependencies": {
         "@nextui-org/react": "^2.4.8",
         "@playwright/test": "1.45.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "playwright-reports-server",
-  "version": "3.1.1",
+  "version": "3.2.0",
   "description": "Playwright Reports Server: Can be used to accept blobs, merge them, store and view Playwright reports",
   "scripts": {
     "build": "next build",


### PR DESCRIPTION
## Rationale
Fixes #37

## Demo
### FS Volume
Url: https://pw-reports.shelex.dev/
Token: 12345

### S3
Url: https://unicorn.shelex.dev/
Token: 12345

## Testing

Emulated 3 separate jobs, reports were generated for projects `parallel-1`, `parallel-2` and `parallel-3`, test names contain job id. 
Verified the fix by checking reports and their tests, each report has tests for specific worker only.