### PR TITLE
Azure fs chmod override

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,8 +53,10 @@ COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
 ARG DATA_DIR=/app/data
 ARG RESULTS_DIR=${DATA_DIR}/results
 ARG REPORTS_DIR=${DATA_DIR}/reports
+ARG TEMP_REPORTS_DIR=/app/temp_reports
 ARG TEMP_DIR=${DATA_DIR}/.tmp
 RUN mkdir -p ${DATA_DIR} && chown -R nextjs:nodejs ${DATA_DIR}
+RUN mkdir -p ${TEMP_REPORTS_DIR} && chown -R nextjs:nodejs ${TEMP_REPORTS_DIR}
 RUN mkdir -p ${RESULTS_DIR} && chown -R nextjs:nodejs ${RESULTS_DIR}
 RUN mkdir -p ${REPORTS_DIR} && chown -R nextjs:nodejs ${REPORTS_DIR}
 RUN mkdir -p ${TEMP_DIR} && chown -R nextjs:nodejs ${TEMP_DIR}

--- a/app/lib/storage/constants.ts
+++ b/app/lib/storage/constants.ts
@@ -9,6 +9,6 @@ export const REPORTS_BUCKET = `${DATA_PATH}/${REPORTS_PATH}`;
 
 export const DATA_FOLDER = path.join(process.cwd(), DATA_PATH);
 export const PW_CONFIG = path.join(process.cwd(), 'playwright.config.ts');
-export const TMP_FOLDER = path.join(DATA_FOLDER, '.tmp');
+export const TMP_FOLDER = path.join(process.cwd(), '.tmp');
 export const RESULTS_FOLDER = path.join(DATA_FOLDER, RESULTS_PATH);
 export const REPORTS_FOLDER = path.join(DATA_FOLDER, REPORTS_PATH);

--- a/app/lib/storage/constants.ts
+++ b/app/lib/storage/constants.ts
@@ -3,12 +3,14 @@ import path from 'node:path';
 export const DATA_PATH = 'data';
 export const RESULTS_PATH = 'results';
 export const REPORTS_PATH = 'reports';
+export const TEMP_REPORTS_PATH = 'temp_reports'
 
 export const RESULTS_BUCKET = `${DATA_PATH}/${RESULTS_PATH}`;
 export const REPORTS_BUCKET = `${DATA_PATH}/${REPORTS_PATH}`;
 
 export const DATA_FOLDER = path.join(process.cwd(), DATA_PATH);
 export const PW_CONFIG = path.join(process.cwd(), 'playwright.config.ts');
-export const TMP_FOLDER = path.join(process.cwd(), '.tmp');
+export const TMP_FOLDER = path.join(DATA_FOLDER, '.tmp');
 export const RESULTS_FOLDER = path.join(DATA_FOLDER, RESULTS_PATH);
 export const REPORTS_FOLDER = path.join(DATA_FOLDER, REPORTS_PATH);
+export const TEMP_REPORTS_FOLDER = path.join(process.cwd(), TEMP_REPORTS_PATH)

--- a/app/lib/storage/overrides.ts
+++ b/app/lib/storage/overrides.ts
@@ -1,0 +1,19 @@
+import fs from 'node:fs/promises';
+
+// This function is used to override chmod 
+// permissions which are not granted by 
+// attached to Docker container Azure File Storage.
+// Unlike fs.cp it does not require chmod permissions.
+export async function recursiveCopyFiles(srcDir: string, destDir: string) {
+    const entries = await fs.readdir(srcDir, { withFileTypes: true });
+    for (const entry of entries) {
+        const srcPath = `${srcDir}/${entry.name}`;
+        const destPath = `${destDir}/${entry.name}`;
+        if (entry.isDirectory()) {
+            await fs.mkdir(destPath, { recursive: true });
+            await recursiveCopyFiles(srcPath, destPath); // Recurse for nested directories
+        } else if (entry.isFile()) {
+            await fs.copyFile(srcPath, destPath);
+        }
+    }
+  }


### PR DESCRIPTION
Generating report when Azure File Storage is mounted at app/data folder throws an error when executing chmod command under playwright merge report command or fs.cp recursive function.