### PR TITLE
Feat/customisable metadata for views

### DIFF
--- a/app/api/report/generate/route.ts
+++ b/app/api/report/generate/route.ts
@@ -6,13 +6,13 @@ export const dynamic = 'force-dynamic'; // defaults to auto
 export async function POST(request: Request) {
   const { result: reqBody, error: reqError } = await withError(request.json());
 
-  const { resultsIds, project } = reqBody;
+  const { resultsIds, project, ...rest } = reqBody;
 
   if (reqError) {
     return new Response(reqError.message, { status: 400 });
   }
 
-  const { result: reportId, error } = await withError(service.generateReport(resultsIds, project));
+  const { result: reportId, error } = await withError(service.generateReport(resultsIds, { project, ...rest }));
 
   if (error) {
     return new Response(error.message, { status: 404 });

--- a/app/api/report/trend/route.ts
+++ b/app/api/report/trend/route.ts
@@ -1,10 +1,6 @@
-import path from 'node:path';
-
 import { type NextRequest } from 'next/server';
 
 import { service } from '@/app/lib/service';
-import { isReportHistory, storage } from '@/app/lib/storage';
-import { parse } from '@/app/lib/parser';
 
 export const dynamic = 'force-dynamic'; // defaults to auto
 
@@ -15,22 +11,5 @@ export async function GET(request: NextRequest) {
 
   const latestReports = reports.slice(0, 20);
 
-  if (!latestReports.length || isReportHistory(latestReports.at(0))) {
-    return Response.json(latestReports);
-  }
-
-  // need to parse stats for each report if service cache not used
-  const latestReportsInfo = await Promise.all(
-    latestReports.map(async (report) => {
-      const html = await storage.readFile(path.join(report.project ?? '', report.reportID, 'index.html'), 'text/html');
-      const info = await parse(html as string);
-
-      return {
-        ...report,
-        ...info,
-      };
-    }),
-  );
-
-  return Response.json(latestReportsInfo);
+  return Response.json(latestReports);
 }

--- a/app/api/report/trend/route.ts
+++ b/app/api/report/trend/route.ts
@@ -1,6 +1,10 @@
+import path from 'node:path';
+
 import { type NextRequest } from 'next/server';
 
 import { service } from '@/app/lib/service';
+import { isReportHistory, storage } from '@/app/lib/storage';
+import { parse } from '@/app/lib/parser';
 
 export const dynamic = 'force-dynamic'; // defaults to auto
 
@@ -11,5 +15,22 @@ export async function GET(request: NextRequest) {
 
   const latestReports = reports.slice(0, 20);
 
-  return Response.json(latestReports);
+  if (!latestReports.length || isReportHistory(latestReports.at(0))) {
+    return Response.json(latestReports);
+  }
+
+  // need to parse stats for each report if service cache not used
+  const latestReportsInfo = await Promise.all(
+    latestReports.map(async (report) => {
+      const html = await storage.readFile(path.join(report.project ?? '', report.reportID, 'index.html'), 'text/html');
+      const info = await parse(html as string);
+
+      return {
+        ...report,
+        ...info,
+      };
+    }),
+  );
+
+  return Response.json(latestReportsInfo);
 }

--- a/app/components/generate-report-button.tsx
+++ b/app/components/generate-report-button.tsx
@@ -11,6 +11,7 @@ import {
   ModalFooter,
   Autocomplete,
   AutocompleteItem,
+  Input,
 } from '@nextui-org/react';
 import { useEffect, useState } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
@@ -53,6 +54,7 @@ export default function GenerateReportButton({
   } = useQuery<string[]>(`/api/result/projects`);
 
   const [projectName, setProjectName] = useState('');
+  const [customName, setCustomName] = useState('');
 
   useEffect(() => {
     !projectName && setProjectName(projects?.at(0) ?? '');
@@ -65,9 +67,10 @@ export default function GenerateReportButton({
       return;
     }
 
-    generateReport({ body: { resultsIds: results.map((r) => r.resultID), project: projectName } });
+    generateReport({ body: { resultsIds: results.map((r) => r.resultID), project: projectName, title: customName } });
 
     setProjectName('');
+    setCustomName('');
     onClose();
     onGeneratedReport?.();
   };
@@ -104,6 +107,15 @@ export default function GenerateReportButton({
                 >
                   {(item) => <AutocompleteItem key={item.value}>{item.label}</AutocompleteItem>}
                 </Autocomplete>
+                <Input
+                  fullWidth
+                  isClearable
+                  maxLength={36}
+                  placeholder="Custom report name"
+                  value={customName}
+                  onChange={(e: { target: { value: any } }) => setCustomName(e.target.value ?? '')}
+                  onClear={() => setCustomName('')}
+                />
               </ModalBody>
               <ModalFooter>
                 <Button color="danger" isDisabled={isPending} onClick={onClose}>

--- a/app/components/login-form.tsx
+++ b/app/components/login-form.tsx
@@ -63,10 +63,10 @@ export default function LoginForm() {
             <Input
               fullWidth
               isRequired
-              type='password'
               errorMessage={error}
               isInvalid={!!error}
               placeholder="Enter API Key"
+              type="password"
               value={input}
               onChange={(e) => {
                 const newValue = e.target.value;

--- a/app/components/report-details/test-info.tsx
+++ b/app/components/report-details/test-info.tsx
@@ -19,7 +19,7 @@ interface TestInfoProps {
 const getTestHistory = (testId: string, history: ReportHistory[]) => {
   return history
     .map((report) => {
-      const file = report.files.find((file) => file.tests.some((test) => test.testId === testId));
+      const file = report?.files?.find((file) => file.tests.some((test) => test.testId === testId));
 
       if (!file) {
         return;
@@ -44,6 +44,8 @@ const getTestHistory = (testId: string, history: ReportHistory[]) => {
 const TestInfo: React.FC<TestInfoProps> = ({ test, history }: TestInfoProps) => {
   const formatted = testStatusToColor(test.outcome);
 
+  const testHistory = getTestHistory(test.testId, history);
+
   return (
     <div className=" shadow-md rounded-lg p-6">
       <div className="mb-4">
@@ -55,39 +57,41 @@ const TestInfo: React.FC<TestInfoProps> = ({ test, history }: TestInfoProps) => 
         {test.annotations.length > 0 && <p>Annotations: {test.annotations.map((a) => JSON.stringify(a)).join(', ')}</p>}
         {test.tags.length > 0 && <p>Tags: {test.tags.join(', ')}</p>}
       </div>
-      <div>
-        <h3 className={subtitle()}>Results:</h3>
-        <Table aria-label="Test History">
-          <TableHeader>
-            <TableColumn>Created At</TableColumn>
-            <TableColumn>Status</TableColumn>
-            <TableColumn>Duration</TableColumn>
-            <TableColumn>Actions</TableColumn>
-          </TableHeader>
-          <TableBody items={getTestHistory(test.testId, history)}>
-            {(item) => {
-              const itemOutcome = testStatusToColor(item?.outcome);
+      {!!testHistory?.length && (
+        <div>
+          <h3 className={subtitle()}>Results:</h3>
+          <Table aria-label="Test History">
+            <TableHeader>
+              <TableColumn>Created At</TableColumn>
+              <TableColumn>Status</TableColumn>
+              <TableColumn>Duration</TableColumn>
+              <TableColumn>Actions</TableColumn>
+            </TableHeader>
+            <TableBody items={testHistory}>
+              {(item) => {
+                const itemOutcome = testStatusToColor(item?.outcome);
 
-              return (
-                <TableRow key={`${item.reportID}-${item.testId}`}>
-                  <TableCell className="w-3/8">
-                    <FormattedDate date={item?.createdAt} />
-                  </TableCell>
-                  <TableCell className="w-2/8">
-                    <span className={itemOutcome.color}>{itemOutcome.title}</span>
-                  </TableCell>
-                  <TableCell className="w-2/8">{parseMilliseconds(item.duration)}</TableCell>
-                  <TableCell className="w-1/8">
-                    <Link href={`${item.reportUrl}#?testId=${item.testId}`} target="_blank">
-                      <LinkIcon />
-                    </Link>
-                  </TableCell>
-                </TableRow>
-              );
-            }}
-          </TableBody>
-        </Table>
-      </div>
+                return (
+                  <TableRow key={`${item.reportID}-${item.testId}`}>
+                    <TableCell className="w-3/8">
+                      <FormattedDate date={item?.createdAt} />
+                    </TableCell>
+                    <TableCell className="w-2/8">
+                      <span className={itemOutcome.color}>{itemOutcome.title}</span>
+                    </TableCell>
+                    <TableCell className="w-2/8">{parseMilliseconds(item.duration)}</TableCell>
+                    <TableCell className="w-1/8">
+                      <Link href={`${item.reportUrl}#?testId=${item.testId}`} target="_blank">
+                        <LinkIcon />
+                      </Link>
+                    </TableCell>
+                  </TableRow>
+                );
+              }}
+            </TableBody>
+          </Table>
+        </div>
+      )}
     </div>
   );
 };

--- a/app/components/reports-table.tsx
+++ b/app/components/reports-table.tsx
@@ -29,7 +29,7 @@ import { EyeIcon } from '@/app/components/icons';
 import { ReadReportsHistory } from '@/app/lib/storage';
 
 const columns = [
-  { name: 'ID', uid: 'reportID' },
+  { name: 'Title', uid: 'title' },
   { name: 'Project', uid: 'project' },
   { name: 'Created At', uid: 'createdAt' },
   { name: 'Size', uid: 'size' },
@@ -40,7 +40,7 @@ interface ReportsTableProps {
   onChange: () => void;
 }
 
-export default function ReportsTable({ onChange }: ReportsTableProps) {
+export default function ReportsTable({ onChange }: Readonly<ReportsTableProps>) {
   const reportListEndpoint = '/api/report/list';
   const [project, setProject] = useState(defaultProjectName);
   const [page, setPage] = useState(1);
@@ -137,7 +137,7 @@ export default function ReportsTable({ onChange }: ReportsTableProps) {
               <TableCell className="w-1/2">
                 <Link href={`/report/${item.reportID}`} prefetch={false}>
                   <div className="flex flex-row">
-                    {item.reportID} <LinkIcon />
+                    {item.title || item.reportID} <LinkIcon />
                   </div>
                 </Link>
               </TableCell>

--- a/app/components/results-table.tsx
+++ b/app/components/results-table.tsx
@@ -25,7 +25,7 @@ import { ReadResultsOutput, type Result } from '@/app/lib/storage';
 import DeleteResultsButton from '@/app/components/delete-results-button';
 
 const columns = [
-  { name: 'ID', uid: 'resultID' },
+  { name: 'Title', uid: 'title' },
   { name: 'Project', uid: 'project' },
   { name: 'Created At', uid: 'createdAt' },
   { name: 'Tags', uid: 'tags' },
@@ -33,7 +33,7 @@ const columns = [
   { name: 'Actions', uid: 'actions' },
 ];
 
-const notMetadataKeys = ['resultID', 'createdAt', 'size', 'sizeBytes', 'project'];
+const notMetadataKeys = ['resultID', 'title', 'createdAt', 'size', 'sizeBytes', 'project'];
 
 const getTags = (item: Result) => {
   return Object.entries(item).filter(([key]) => !notMetadataKeys.includes(key));
@@ -160,7 +160,7 @@ export default function ResultsTable({ onSelect, onDeleted, selected }: Readonly
         >
           {(item) => (
             <TableRow key={item.resultID}>
-              <TableCell className="w-1/3">{item.resultID}</TableCell>
+              <TableCell className="w-1/3">{item.title ?? item.resultID}</TableCell>
               <TableCell className="w-1/6">{item.project}</TableCell>
               <TableCell className="w-1/12">
                 <FormattedDate date={new Date(item.createdAt)} />

--- a/app/lib/parser/index.ts
+++ b/app/lib/parser/index.ts
@@ -6,7 +6,7 @@ import { withError } from '@/app/lib/withError';
 
 export * from './types';
 
-export const parse = async (html: string) => {
+export const parse = async (html: string): Promise<ReportInfo> => {
   const base64Prefix = 'data:application/zip;base64,';
   const start = html.indexOf('window.playwrightReportBase64 = "') + 'window.playwrightReportBase64 = "'.length;
   const end = html.indexOf('";', start);
@@ -36,12 +36,12 @@ export const parse = async (html: string) => {
 
   const reportJson = await reportFile.async('string');
 
-  return JSON.parse(reportJson) as ReportInfo;
+  return JSON.parse(reportJson);
 };
 
 export const parseHtmlReport = async (html: string) => {
   try {
-    return parse(html);
+    return await parse(html);
   } catch (e: unknown) {
     if (e instanceof Error) {
       console.error(e.message);

--- a/app/lib/service/index.ts
+++ b/app/lib/service/index.ts
@@ -1,5 +1,3 @@
-import path from 'node:path';
-
 import { withError } from '../withError';
 import { bytesToString, getUniqueProjectsList } from '../storage/format';
 
@@ -10,12 +8,12 @@ import {
   ReadResultsInput,
   ReadResultsOutput,
   ReportHistory,
+  ReportMetadata,
   ResultDetails,
   ServerDataInfo,
   isReportHistory,
   storage,
 } from '@/app/lib/storage';
-import { parse } from '@/app/lib/parser';
 import { handlePagination } from '@/app/lib/storage/pagination';
 import { UUID } from '@/app/types';
 
@@ -81,29 +79,11 @@ class Service {
       throw new Error(`report with id ${id} not found`);
     }
 
-    if (isReportHistory(report)) {
-      return report;
-    }
-
-    const { result: html, error: readHtmlError } = await withError(
-      storage.readFile(path.join(report?.project ?? '', id, 'index.html'), 'text/html'),
-    );
-
-    if (readHtmlError || !html) {
-      throw new Error(`failed to read report html file: ${readHtmlError?.message ?? 'unknown error'}`);
-    }
-
-    const { result: info, error: parseError } = await withError(parse(html as string));
-
-    if (parseError || !info) {
-      throw new Error(`failed to parse report html file: ${parseError?.message ?? 'unknown error'}`);
-    }
-
-    return { ...report!, ...info };
+    return report;
   }
 
-  public async generateReport(resultsIds: string[], project?: string): Promise<string> {
-    const reportId = await storage.generateReport(resultsIds, project);
+  public async generateReport(resultsIds: string[], metadata?: ReportMetadata): Promise<string> {
+    const reportId = await storage.generateReport(resultsIds, metadata);
 
     const report = await this.getReport(reportId);
 

--- a/app/lib/storage/constants.ts
+++ b/app/lib/storage/constants.ts
@@ -14,3 +14,5 @@ export const PW_CONFIG = path.join(CWD, 'playwright.config.ts');
 export const TMP_FOLDER = path.join(CWD, '.tmp');
 export const RESULTS_FOLDER = path.join(DATA_FOLDER, RESULTS_PATH);
 export const REPORTS_FOLDER = path.join(DATA_FOLDER, REPORTS_PATH);
+
+export const REPORT_METADATA_FILE = 'report-server-metadata.json';

--- a/app/lib/storage/types.ts
+++ b/app/lib/storage/types.ts
@@ -48,6 +48,7 @@ export interface ResultDetails {
 
 export type Result = {
   resultID: UUID;
+  title?: string;
   createdAt: string;
   project: string;
   size: string;
@@ -56,6 +57,7 @@ export type Result = {
 
 export type Report = {
   reportID: string;
+  title?: string;
   project: string;
   reportUrl: string;
   createdAt: Date;

--- a/app/lib/storage/types.ts
+++ b/app/lib/storage/types.ts
@@ -11,7 +11,7 @@ export interface Storage {
   deleteResults: (resultIDs: string[]) => Promise<void>;
   deleteReports: (reportIDs: string[]) => Promise<void>;
   saveResult: (file: Blob, size: number, resultDetails: ResultDetails) => Promise<Result>;
-  generateReport: (resultsIds: string[], project?: string) => Promise<UUID>;
+  generateReport: (resultsIds: string[], metadata?: ReportMetadata) => Promise<UUID>;
   moveReport: (oldPath: string, newPath: string) => Promise<void>;
 }
 
@@ -32,7 +32,7 @@ export interface ReadReportsInput {
 }
 
 export interface ReadReportsOutput {
-  reports: Report[];
+  reports: ReportHistory[];
   total: number;
 }
 
@@ -71,6 +71,8 @@ export const isReportHistory = (report: Report | ReportHistory | undefined): rep
   !!report && typeof report === 'object' && 'stats' in report;
 
 export type TestHistory = Report & ReportTest;
+
+export type ReportMetadata = Partial<{ title: string; project: string }> & Record<string, string>;
 
 export interface ServerDataInfo {
   dataFolderSizeinMB: string;

--- a/app/report/[id]/page.tsx
+++ b/app/report/[id]/page.tsx
@@ -46,7 +46,7 @@ function ReportDetail({ params }: Readonly<ReportDetailProps>) {
   return (
     <>
       <div className="text-center">
-        <h1 className={title()}>Report</h1>
+        <h1 className={title()}>{report?.title || 'Report'}</h1>
         {report?.createdAt && (
           <span className={subtitle()}>
             <FormattedDate date={report.createdAt} />

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "playwright-reports-server",
-  "version": "4.0.1",
+  "version": "4.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "playwright-reports-server",
-      "version": "4.0.1",
+      "version": "4.1.0",
       "dependencies": {
         "@nextui-org/react": "^2.4.8",
         "@playwright/test": "1.45.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "playwright-reports-server",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "playwright-reports-server",
-      "version": "4.0.0",
+      "version": "4.0.1",
       "dependencies": {
         "@nextui-org/react": "^2.4.8",
         "@playwright/test": "1.45.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "playwright-reports-server",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "Playwright Reports Server: Can be used to accept blobs, merge them, store and view Playwright reports",
   "scripts": {
     "build": "next build",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "playwright-reports-server",
-  "version": "4.0.1",
+  "version": "4.1.0",
   "description": "Playwright Reports Server: Can be used to accept blobs, merge them, store and view Playwright reports",
   "scripts": {
     "build": "next build",

--- a/readme.md
+++ b/readme.md
@@ -80,12 +80,7 @@ Returns list of generated reports and corresponding url on server:
 ```sh
 curl --location --request GET 'http://localhost:3000/api/report/list' \
 --header 'Content-Type: application/json' \
---header 'Authorization: <api-token>' \
---data '{
-    "reportsIds": [
-        "6a615fe1-2452-4867-9ae5-6ee68313aac6"
-    ]
-}'
+--header 'Authorization: <api-token>'
 ```
 
 Response example:
@@ -99,6 +94,7 @@ Response example:
       "project": "regression",
       "size": "6.97 MB",
       "reportUrl": "/api/serve/regression/8e9af87d-1d10-4729-aefd-3e92ee64d06c/index.html"
+      //...parsed info
     },
     {
       "reportID": "8fe427ed-783c-4fb9-aacc-ba6fbc5f5667",
@@ -106,6 +102,7 @@ Response example:
       "project": "smoke",
       "size": "1.53 MB",
       "reportUrl": "/api/serve/smoke/8fe427ed-783c-4fb9-aacc-ba6fbc5f5667/index.html"
+      //...parsed info
     }
   ],
   "total": 2


### PR DESCRIPTION
## Features
- pass `title` property to `/api/result/upload` to have custom title for result file
- pass `title` property to `/api/report/generate` to have custom title for report

## Fixes

- fix trends page when service cache is disabled
- minor eslint fixes and readme updates

## Internals
- now reports have file `report-server-metadata.json` which may contain custom information and parsed report information
- for previously existing reports it will be created on next fetch.
