### PR TITLE
#65 Improve cross-platform start script

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "next build",
     "dev": "next dev",
-    "start": "cp -r .next/static .next/standalone/.next/ && cp -r ./public .next/standalone/public && node .next/standalone/server.js",
+    "start": "node scripts/start.js",
     "format:check": "prettier --ignore-path .gitignore --list-different '**/**/*.{ts,json,md}'",
     "format:fix": "npm run format:check -- --write",
     "lint": "eslint . --ext .ts,.tsx",

--- a/readme.md
+++ b/readme.md
@@ -71,6 +71,10 @@ Check out the live demo: [familiar-alyss-alex-hot-6926ec9c.koyeb.app](https://fa
    npm run build && npm run start
    ```
 
+   The `start` script uses a small Node.js utility to copy the build assets
+   before launching the server, so it works on Windows without requiring Unix
+   commands.
+
 2. The application will be accessible at `http://localhost:3000`.
    All data will be stored at `/data/` folder. You can backup it, to keep your data safe.
 

--- a/scripts/start.js
+++ b/scripts/start.js
@@ -1,0 +1,16 @@
+const { cpSync } = require('fs');
+const { join } = require('path');
+const { spawn } = require('child_process');
+
+function copyDir(src, dest) {
+  cpSync(src, dest, { recursive: true, force: true });
+}
+
+copyDir(join('.next', 'static'), join('.next', 'standalone', '.next', 'static'));
+copyDir('public', join('.next', 'standalone', 'public'));
+
+const server = spawn('node', [join('.next', 'standalone', 'server.js')], {
+  stdio: 'inherit',
+});
+
+server.on('close', (code) => process.exit(code));


### PR DESCRIPTION
## Summary
- use a node script for `npm start` so Windows users don't need `cp`
- mention the new cross-platform start command in the docs

## Testing
- `npm run lint` *(fails: ESLint couldn't find an eslint config)*
- `npm test` *(fails: jest not found)*