### PR TITLE
Fix/theme inconsistency and custom title

### DIFF
--- a/app/components/aside.tsx
+++ b/app/components/aside.tsx
@@ -22,7 +22,7 @@ export const Aside: React.FC = () => {
     dependencies: [],
   });
 
-  const isAuthenticated = session.status === 'unauthenticated';
+  const isAuthenticated = session.status === 'authenticated';
 
   return (
     <Card className="w-16 h-full rounded-none border-r border-gray-200 dark:border-gray-800 dark:bg-black shadow-none">
@@ -48,7 +48,7 @@ export const Aside: React.FC = () => {
                     : 'hover:bg-[#EEF7FC] dark:hover:bg-black'
                 }`}
                 href={item.href}
-                isDisabled={isAuthenticated}
+                isDisabled={!isAuthenticated}
                 title={item.label}
               >
                 {count !== undefined && count > 0 ? (

--- a/app/components/aside.tsx
+++ b/app/components/aside.tsx
@@ -3,6 +3,7 @@
 import { Card, CardBody, Link, Badge } from '@heroui/react';
 import NextLink from 'next/link';
 import { usePathname } from 'next/navigation';
+import { useSession } from 'next-auth/react';
 
 import { ReportIcon, ResultIcon } from '@/app/components/icons';
 import { siteConfig } from '@/app/config/site';
@@ -15,10 +16,13 @@ interface ServerInfo {
 
 export const Aside: React.FC = () => {
   const pathname = usePathname();
+  const session = useSession();
 
   const { data: serverInfo } = useQuery<ServerInfo>('/api/info', {
     dependencies: [],
   });
+
+  const isAuthenticated = session.status === 'unauthenticated';
 
   return (
     <Card className="w-16 h-full rounded-none border-r border-gray-200 dark:border-gray-800 dark:bg-black shadow-none">
@@ -44,6 +48,7 @@ export const Aside: React.FC = () => {
                     : 'hover:bg-[#EEF7FC] dark:hover:bg-black'
                 }`}
                 href={item.href}
+                isDisabled={isAuthenticated}
                 title={item.label}
               >
                 {count !== undefined && count > 0 ? (

--- a/app/components/navbar.tsx
+++ b/app/components/navbar.tsx
@@ -11,7 +11,9 @@ import Image from 'next/image';
 import { Link } from '@heroui/link';
 import NextLink from 'next/link';
 
-import { getConfigWithError } from '@/app/lib/actions';
+import { subtitle } from './primitives';
+
+import { defaultConfig, getConfigWithError } from '@/app/lib/actions';
 import { HeaderLinks } from '@/app/components/header-links';
 import { siteConfig } from '@/app/config/site';
 import { ThemeSwitch } from '@/app/components/theme-switch';
@@ -19,6 +21,9 @@ import { SiteWhiteLabelConfig } from '@/app/types';
 
 export const Navbar: React.FC = async () => {
   const { result: config }: { result?: SiteWhiteLabelConfig } = await getConfigWithError();
+
+  const isCustomLogo = config?.logoPath !== defaultConfig.logoPath;
+  const isCustomTitle = config?.title !== defaultConfig.title;
 
   return (
     <NextUINavbar
@@ -36,12 +41,13 @@ export const Navbar: React.FC = async () => {
             <Image
               unoptimized
               alt="Logo"
-              className="min-w-10 dark:invert"
+              className={`min-w-10 dark:invert ${isCustomLogo ? 'max-w-10' : ''}`}
               height="31"
               src={`/api/static${config?.logoPath}`}
               width="174"
             />
           </NextLink>
+          {isCustomTitle && <h1 className={subtitle()}>{config?.title}</h1>}
         </NavbarBrand>
       </NavbarContent>
 

--- a/app/components/theme-switch.tsx
+++ b/app/components/theme-switch.tsx
@@ -2,7 +2,7 @@
 
 import { FC } from 'react';
 import { VisuallyHidden } from '@react-aria/visually-hidden';
-import { SwitchProps, useSwitch } from "@heroui/switch";
+import { SwitchProps, useSwitch } from '@heroui/switch';
 import { useTheme } from 'next-themes';
 import { useIsSSR } from '@react-aria/ssr';
 import clsx from 'clsx';
@@ -15,11 +15,14 @@ export interface ThemeSwitchProps {
 }
 
 export const ThemeSwitch: FC<ThemeSwitchProps> = ({ className, classNames }) => {
-  const { theme, setTheme } = useTheme();
+  const { theme: themeName, setTheme } = useTheme();
   const isSSR = useIsSSR();
 
+  // normalize theme name for compatibility with theme picker from playwright trace view
+  const theme = themeName?.replace('-mode', '');
+
   const onChange = () => {
-    theme === 'light' ? setTheme('dark') : setTheme('light');
+    theme === 'light' ? setTheme('dark-mode') : setTheme('light-mode');
   };
 
   const { Component, slots, isSelected, getBaseProps, getInputProps, getWrapperProps } = useSwitch({

--- a/app/providers/index.tsx
+++ b/app/providers/index.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import  { FC, useState } from 'react';
-import { HeroUIProvider } from "@heroui/system";
+import { FC, useState } from 'react';
+import { HeroUIProvider } from '@heroui/system';
 import { ThemeProvider as NextThemesProvider } from 'next-themes';
 import { ThemeProviderProps } from 'next-themes/dist/types';
 import { SessionProvider } from 'next-auth/react';
@@ -22,7 +22,14 @@ export const Providers: FC<ThemeProviderProps> = ({ children, ...themeProps }) =
 
   return (
     <HeroUIProvider>
-      <NextThemesProvider {...themeProps}>
+      <NextThemesProvider
+        {...themeProps}
+        // additional mapping to handle theme names from playwright trace view
+        value={{
+          'light-mode': 'light',
+          'dark-mode': 'dark',
+        }}
+      >
         <QueryClientProvider client={queryClient}>
           <SessionProvider>{children}</SessionProvider>
           <ReactQueryDevtools initialIsOpen={false} />


### PR DESCRIPTION
### Fixes
- conflicting theme handling with playwright trace view. 
> changed app theme names to same values as trace viewer, but under the hood (in DOM) they will still be same as previously, only local storage value is handled differently.
- added back support for custom title
> now default app logo includes text title, so added check that if it is different from default - display the custom title. Fixed the display for custom logo as well.
- disable sidebar page links when user not authenticated yet
> currently those links are available from login page, but that makes no sense, as click redirects to login page anyway.