### PR TITLE
fix: presigned url key for s3 should contain file extension

### DIFF
--- a/app/lib/service/index.ts
+++ b/app/lib/service/index.ts
@@ -229,12 +229,12 @@ class Service {
     resultCache.onDeleted(resultIDs);
   }
 
-  public async getPresignedUrl(resultID: string): Promise<string | undefined> {
-    console.log(`[service] getPresignedUrl for ${resultID}`);
+  public async getPresignedUrl(fileName: string): Promise<string | undefined> {
+    console.log(`[service] getPresignedUrl for ${fileName}`);
     if (env.DATA_STORAGE === 's3') {
       console.log(`[service] s3 detected, generating presigned URL`);
 
-      const { result: presignedUrl, error } = await withError((storage as S3).generatePresignedUploadUrl(resultID));
+      const { result: presignedUrl, error } = await withError((storage as S3).generatePresignedUploadUrl(fileName));
 
       if (error) {
         console.error(`[service] getPresignedUrl | error: ${error.message}`);

--- a/pages/api/result/upload.ts
+++ b/pages/api/result/upload.ts
@@ -34,7 +34,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   let fileSize = 0;
 
   // if there is fileContentLength query parameter we can use presigned URL for direct upload
-  const presignedUrl = contentLength ? await service.getPresignedUrl(resultID) : '';
+  const presignedUrl = contentLength ? await service.getPresignedUrl(fileName) : '';
 
   const filePassThrough = new PassThrough({
     highWaterMark: DEFAULT_STREAM_CHUNK_SIZE,


### PR DESCRIPTION
### Issue
when file is saved via presigned s3 url - it does not contain extension.