### PR TITLE
fix: compatibility with gcp storage

### DIFF
--- a/app/lib/storage/fs.ts
+++ b/app/lib/storage/fs.ts
@@ -449,7 +449,7 @@ async function saveConfigFile(config: Partial<SiteWhiteLabelConfig>) {
   const isConfigFailed = !!configError && configError?.message !== noConfigErr && !existingConfig;
 
   if (isConfigFailed) {
-    throw new Error(`failed to save config: ${configError.message}`);
+    console.error(`failed to read existing config: ${configError.message}`);
   }
 
   const previousConfig = existingConfig ?? defaultConfig;

--- a/readme.md
+++ b/readme.md
@@ -398,6 +398,14 @@ When S3 storage is configured, all operations that would normally interact with 
 
 Note: When switching from local storage to S3 or vice versa, existing data will not be automatically migrated. Ensure you have a backup of your data before changing storage configurations.
 
+3. Google cloud storage specifics
+
+As GCP has quite limited S3 API support, you need to ensure that:
+
+- a bucket with the name `playwright-reports-server` is created or just specify your own bucket name via `S3_BUCKET` environment variable.
+- you set the `S3_REGION` env variable to `auto`, as it does not support custom regions.
+- error message in logs `S3Error: The specified location constraint is not valid.` could mean that you do not have a bucket or not specified the `S3_REGION` env variable.
+
 ### Expiration task
 
 You can specify how much days to keep your report or result files in order to cleanup old records.  


### PR DESCRIPTION
### GCP Storage compatibility
- cannot create bucket via S3 API, should do that via GCP CLI or Console
- does not support regions, `S3_REGION=auto` should be specified
- does not support `removeObjects`

### Fixes
- do not throw error when failed to clear existing config file