### PR TITLE
chore: use listV2 endpoint for s3

### DIFF
--- a/app/lib/service/index.ts
+++ b/app/lib/service/index.ts
@@ -24,6 +24,7 @@ import { defaultConfig } from '@/app/lib/config';
 import { env } from '@/app/config/env';
 import { type S3 } from '@/app/lib/storage/s3';
 import { isValidPlaywrightVersion } from '@/app/lib/pw';
+import { getTimestamp } from '@/app/lib/time';
 
 class Service {
   private static instance: Service;
@@ -78,13 +79,6 @@ class Service {
           return searchableFields.some((field) => field?.toLowerCase().includes(searchTerm));
         });
       }
-
-      const getTimestamp = (date?: Date | string) => {
-        if (!date) return 0;
-        if (typeof date === 'string') return new Date(date).getTime();
-
-        return date.getTime();
-      };
 
       reports.sort((a, b) => getTimestamp(b.createdAt) - getTimestamp(a.createdAt));
       const currentReports = handlePagination<ReportHistory>(reports, input?.pagination);
@@ -214,13 +208,6 @@ class Service {
     if (!cached.length) {
       return await storage.readResults(input);
     }
-
-    const getTimestamp = (date?: Date | string) => {
-      if (!date) return 0;
-      if (typeof date === 'string') return new Date(date).getTime();
-
-      return date.getTime();
-    };
 
     cached.sort((a, b) => getTimestamp(b.createdAt) - getTimestamp(a.createdAt));
 

--- a/app/lib/storage/fs.ts
+++ b/app/lib/storage/fs.ts
@@ -77,8 +77,9 @@ export async function readFile(targetPath: string, contentType: string | null) {
 
 async function getResultsCount() {
   const files = await fs.readdir(RESULTS_FOLDER);
+  const zipFilesCount = files.filter((file) => file.endsWith('.zip'));
 
-  return Math.round(files.length / 2);
+  return zipFilesCount.length;
 }
 
 export async function readResults(input?: ReadResultsInput) {

--- a/app/lib/time.ts
+++ b/app/lib/time.ts
@@ -18,3 +18,10 @@ export const parseMilliseconds = (ms: number) => {
 
   return `${leftMs}ms`;
 };
+
+export const getTimestamp = (date?: Date | string) => {
+  if (!date) return 0;
+  if (typeof date === 'string') return new Date(date).getTime();
+
+  return date.getTime();
+};


### PR DESCRIPTION
- reuse `getTimestamp` function for storage and service methods
- fix the logic for calculating results count for fs storage
- ensure s3 storage uses `listObjectsV2`