### PR TITLE
feat: PDF export, evidence report, date filtering, S3 SSL toggle

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,4 +21,5 @@ S3_SECRET_KEY="some_secret_key"
 S3_PORT=9000 # optional
 S3_REGION="us-east-1"
 S3_BUCKET="bucket_name" # by default "playwright-reports-server"
+S3_USE_SSL=true # set to false for non-SSL MinIO connections
 S3_BATCH_SIZE=10 # by default 10

--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,8 @@ node_modules/
 /playwright-report/
 /blob-report/
 /playwright/.cache/
+
+## all docker files (local)
+docker-compose**.**yml
+!docker-compose.yml
+!Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,10 @@ WORKDIR /app
 
 ENV NODE_ENV=production
 
-RUN apk add --no-cache curl
+# Install Chromium for PDF export feature
+RUN apk add --no-cache curl chromium
+
+ENV PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH=/usr/bin/chromium-browser
 
 # Uncomment the following line in case you want to disable telemetry during runtime.
 # ENV NEXT_TELEMETRY_DISABLED 1
@@ -53,6 +56,18 @@ RUN mkdir .next && \
 # https://nextjs.org/docs/advanced-features/output-file-tracing
 COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
 COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
+
+# Copy playwright packages - standalone tracing omits node_modules/.bin symlinks
+# so npx playwright (used for merge-reports + PDF export) would fail without this.
+# All three packages are needed: @playwright/test CLI delegates to playwright which
+# requires playwright-core.
+COPY --from=builder /app/node_modules/@playwright ./node_modules/@playwright
+COPY --from=builder /app/node_modules/playwright ./node_modules/playwright
+COPY --from=builder /app/node_modules/playwright-core ./node_modules/playwright-core
+RUN mkdir -p node_modules/.bin && \
+    ln -sf /app/node_modules/@playwright/test/cli.js node_modules/.bin/playwright && \
+    chmod +x node_modules/@playwright/test/cli.js && \
+    chown -R nextjs:nodejs node_modules/@playwright node_modules/playwright node_modules/playwright-core node_modules/.bin/playwright
 
 # Create folders required for storing results and reports
 ARG DATA_DIR=/app/data

--- a/app/api/download/[id]/route.ts
+++ b/app/api/download/[id]/route.ts
@@ -1,0 +1,356 @@
+import path from 'node:path';
+
+import JSZip from 'jszip';
+import { type NextRequest } from 'next/server';
+import { redirect } from 'next/navigation';
+
+import { withError } from '@/app/lib/withError';
+import { service } from '@/app/lib/service';
+import { storage } from '@/app/lib/storage';
+import { auth } from '@/app/auth';
+import { env } from '@/app/config/env';
+import { withBase } from '@/app/lib/url';
+import { parse } from '@/app/lib/parser';
+import { ReportTestOutcome, type ReportInfo, type ReportTest } from '@/app/lib/parser/types';
+
+export const dynamic = 'force-dynamic';
+export const maxDuration = 120;
+
+function safeFilename(name: string): string {
+  return name.replace(/[^a-zA-Z0-9._-]/g, '_').replace(/_{2,}/g, '_');
+}
+
+// ─── Auth guard (same pattern as /api/serve) ─────────────────────────────────
+
+async function guardAuth(req: NextRequest) {
+  const authRequired = !!env.API_TOKEN;
+  const session = await auth();
+
+  if (authRequired && !session?.user?.jwtToken) {
+    redirect(withBase(`/login?callbackUrl=${encodeURI(req.nextUrl.pathname + req.nextUrl.search)}`));
+  }
+}
+
+// ─── ZIP export ───────────────────────────────────────────────────────────────
+
+async function exportZip(reportId: string, project: string, title: string): Promise<Response> {
+  const { result: files, error: listError } = await withError(storage.listReportFiles(reportId, project));
+
+  if (listError || !files) {
+    return new Response(`failed to list report files: ${listError?.message ?? 'unknown error'}`, { status: 500 });
+  }
+
+  const zip = new JSZip();
+
+  for (const file of files) {
+    const { result: content, error: readError } = await withError(storage.readFile(file.storagePath, null));
+
+    if (readError || content === undefined || content === null) {
+      console.error(`[download] failed to read ${file.storagePath}: ${readError?.message}`);
+      continue;
+    }
+
+    zip.file(file.relativePath, typeof content === 'string' ? Buffer.from(content, 'utf-8') : content);
+  }
+
+  const buffer = await zip.generateAsync({ type: 'nodebuffer', compression: 'DEFLATE' });
+
+  return new Response(buffer, {
+    headers: {
+      'Content-Type': 'application/zip',
+      'Content-Disposition': `attachment; filename="${safeFilename(title)}.zip"`,
+    },
+  });
+}
+
+// ─── Playwright SPA PDF export ────────────────────────────────────────────────
+
+async function exportPdf(reportId: string, project: string, title: string, req: NextRequest): Promise<Response> {
+  let chromium: typeof import('@playwright/test').chromium;
+
+  try {
+    const pw = await import('@playwright/test');
+
+    chromium = pw.chromium;
+  } catch {
+    return new Response('Playwright is not available in this environment', { status: 500 });
+  }
+
+  const host = req.headers.get('host') ?? 'localhost:3000';
+  const protocol = req.headers.get('x-forwarded-proto') ?? 'http';
+  const projectSegment = project ? `${encodeURIComponent(project)}/` : '';
+  const reportUrl = `${protocol}://${host}/api/serve/${projectSegment}${reportId}/index.html`;
+  const executablePath = process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH;
+
+  const browser = await chromium.launch({
+    executablePath: executablePath || undefined,
+    args: ['--no-sandbox', '--disable-setuid-sandbox', '--disable-dev-shm-usage'],
+  });
+
+  try {
+    const context = await browser.newContext();
+    const cookieHeader = req.headers.get('cookie');
+
+    if (cookieHeader) {
+      const cookies = cookieHeader.split(';').map((pair) => {
+        const [name, ...rest] = pair.trim().split('=');
+
+        return { name: name.trim(), value: rest.join('=').trim(), domain: host.split(':')[0], path: '/' };
+      });
+
+      await context.addCookies(cookies);
+    }
+
+    const page = await context.newPage();
+
+    await page.goto(reportUrl, { waitUntil: 'networkidle', timeout: 60_000 });
+
+    const pdf = await page.pdf({
+      format: 'A4',
+      printBackground: true,
+      margin: { top: '10mm', right: '10mm', bottom: '10mm', left: '10mm' },
+    });
+
+    return new Response(pdf, {
+      headers: {
+        'Content-Type': 'application/pdf',
+        'Content-Disposition': `attachment; filename="${safeFilename(title)}.pdf"`,
+      },
+    });
+  } finally {
+    await browser.close();
+  }
+}
+
+// ─── Evidence PDF: test name + screenshot per test ────────────────────────────
+
+const outcomeColor: Record<ReportTestOutcome, string> = {
+  [ReportTestOutcome.Expected]: '#16a34a',
+  [ReportTestOutcome.Unexpected]: '#dc2626',
+  [ReportTestOutcome.Flaky]: '#d97706',
+  [ReportTestOutcome.Skipped]: '#6b7280',
+};
+
+const outcomeLabel: Record<ReportTestOutcome, string> = {
+  [ReportTestOutcome.Expected]: 'PASSED',
+  [ReportTestOutcome.Unexpected]: 'FAILED',
+  [ReportTestOutcome.Flaky]: 'FLAKY',
+  [ReportTestOutcome.Skipped]: 'SKIPPED',
+};
+
+async function readScreenshotAsDataUrl(
+  screenshotPath: string,
+  reportId: string,
+  project: string,
+): Promise<string | null> {
+  const storagePath = path.join(project, reportId, screenshotPath);
+  const { result: buf, error } = await withError(storage.readFile(storagePath, null));
+
+  if (error || !buf) return null;
+
+  const b64 = Buffer.isBuffer(buf) ? buf.toString('base64') : Buffer.from(buf as string, 'binary').toString('base64');
+  const ext = path.extname(screenshotPath).replace('.', '') || 'png';
+  const mime = ext === 'jpg' || ext === 'jpeg' ? 'image/jpeg' : ext === 'webp' ? 'image/webp' : 'image/png';
+
+  return `data:${mime};base64,${b64}`;
+}
+
+function buildTestRow(test: ReportTest, screenshotDataUrl: string | null): string {
+  const fullName = [...test.path, test.title].join(' › ');
+  const color = outcomeColor[test.outcome];
+  const label = outcomeLabel[test.outcome];
+  const durationSec = (test.duration / 1000).toFixed(1);
+
+  const screenshotHtml = screenshotDataUrl
+    ? `<img alt="screenshot" src="${screenshotDataUrl}" style="max-width:100%;border:1px solid #e5e7eb;border-radius:4px;margin-top:8px;" />`
+    : '';
+
+  return `
+    <div style="break-inside:avoid;margin-bottom:24px;padding:16px;border:1px solid #e5e7eb;border-radius:6px;background:#fff;">
+      <div style="display:flex;align-items:flex-start;gap:10px;">
+        <span style="flex-shrink:0;padding:2px 8px;border-radius:4px;font-size:11px;font-weight:700;color:#fff;background:${color};">${label}</span>
+        <div style="flex:1;min-width:0;">
+          <div style="font-size:13px;font-weight:600;color:#111;word-break:break-word;">${fullName}</div>
+          <div style="font-size:11px;color:#6b7280;margin-top:2px;">${test.location.file}:${test.location.line} &nbsp;·&nbsp; ${durationSec}s</div>
+        </div>
+      </div>
+      ${screenshotHtml}
+    </div>`;
+}
+
+function buildEvidenceHtml(info: ReportInfo, title: string, reportId: string, testRows: string[]): string {
+  const { stats } = info;
+  const passRate = stats.total > 0 ? Math.round((stats.expected / stats.total) * 100) : 0;
+  const date = new Date().toLocaleString();
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8"/>
+<style>
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; background: #f9fafb; color: #111; padding: 32px; }
+  h1 { font-size: 22px; font-weight: 700; margin-bottom: 4px; }
+  .meta { font-size: 12px; color: #6b7280; margin-bottom: 20px; }
+  .summary { display: flex; gap: 16px; flex-wrap: wrap; margin-bottom: 28px; padding: 16px; background: #fff; border: 1px solid #e5e7eb; border-radius: 8px; }
+  .stat { text-align: center; }
+  .stat-value { font-size: 24px; font-weight: 700; }
+  .stat-label { font-size: 11px; color: #6b7280; text-transform: uppercase; letter-spacing: .05em; }
+  .section-title { font-size: 13px; font-weight: 600; color: #374151; margin: 24px 0 12px; padding-bottom: 6px; border-bottom: 2px solid #e5e7eb; }
+  @media print { body { padding: 0; background: #fff; } }
+</style>
+</head>
+<body>
+  <h1>${title}</h1>
+  <div class="meta">Generated ${date} &nbsp;·&nbsp; Report ID: ${reportId}</div>
+  <div class="summary">
+    <div class="stat"><div class="stat-value" style="color:#111;">${stats.total}</div><div class="stat-label">Total</div></div>
+    <div class="stat"><div class="stat-value" style="color:#16a34a;">${stats.expected}</div><div class="stat-label">Passed</div></div>
+    <div class="stat"><div class="stat-value" style="color:#dc2626;">${stats.unexpected}</div><div class="stat-label">Failed</div></div>
+    <div class="stat"><div class="stat-value" style="color:#d97706;">${stats.flaky}</div><div class="stat-label">Flaky</div></div>
+    <div class="stat"><div class="stat-value" style="color:#6b7280;">${stats.skipped}</div><div class="stat-label">Skipped</div></div>
+    <div class="stat"><div class="stat-value" style="color:#2563eb;">${passRate}%</div><div class="stat-label">Pass Rate</div></div>
+  </div>
+  ${testRows.join('\n')}
+</body>
+</html>`;
+}
+
+async function exportEvidence(
+  reportId: string,
+  project: string,
+  title: string,
+): Promise<Response> {
+  // Read and parse the report HTML to get full test tree with attachments
+  const indexPath = path.join(project, reportId, 'index.html');
+  const { result: htmlContent, error: readError } = await withError(storage.readFile(indexPath, 'text/html'));
+
+  if (readError || !htmlContent) {
+    return new Response('failed to read report html', { status: 500 });
+  }
+
+  const { result: info, error: parseError } = await withError(parse(htmlContent.toString()));
+
+  if (parseError || !info) {
+    return new Response('failed to parse report data', { status: 500 });
+  }
+
+  // Build one HTML block per test, embedding the first screenshot attachment
+  const testRows: string[] = [];
+
+  for (const file of info.files) {
+    testRows.push(`<div class="section-title">${file.fileName}</div>`);
+
+    for (const test of file.tests) {
+      // Find the first screenshot attachment across all results
+      let screenshotDataUrl: string | null = null;
+
+      for (const result of test.results) {
+        for (const attachment of result.attachments) {
+          if (attachment.contentType.startsWith('image/') && attachment.path) {
+            screenshotDataUrl = await readScreenshotAsDataUrl(attachment.path, reportId, project);
+            if (screenshotDataUrl) break;
+          }
+        }
+        if (screenshotDataUrl) break;
+      }
+
+      testRows.push(buildTestRow(test, screenshotDataUrl));
+    }
+  }
+
+  const html = buildEvidenceHtml(info, title, reportId, testRows);
+
+  // Render to PDF via Playwright
+  let chromium: typeof import('@playwright/test').chromium;
+
+  try {
+    const pw = await import('@playwright/test');
+
+    chromium = pw.chromium;
+  } catch {
+    return new Response('Playwright is not available in this environment', { status: 500 });
+  }
+
+  const executablePath = process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH;
+  const browser = await chromium.launch({
+    executablePath: executablePath || undefined,
+    args: ['--no-sandbox', '--disable-setuid-sandbox', '--disable-dev-shm-usage'],
+  });
+
+  try {
+    const page = await browser.newPage();
+
+    await page.setContent(html, { waitUntil: 'networkidle' });
+
+    const headerHtml = `
+      <div style="width:100%;font-family:sans-serif;font-size:9px;color:#6b7280;padding:0 15mm;display:flex;justify-content:space-between;">
+        <span>${title}</span>
+        <span>${new Date().toLocaleDateString()}</span>
+      </div>`;
+
+    const footerHtml = `
+      <div style="width:100%;font-family:sans-serif;font-size:9px;color:#6b7280;padding:0 15mm;display:flex;justify-content:space-between;">
+        <span>Playwright Reports Server</span>
+        <span>Page <span class="pageNumber"></span> of <span class="totalPages"></span></span>
+      </div>`;
+
+    const pdf = await page.pdf({
+      format: 'A4',
+      printBackground: true,
+      displayHeaderFooter: true,
+      headerTemplate: headerHtml,
+      footerTemplate: footerHtml,
+      // top/bottom margin must be large enough to clear the header/footer
+      margin: { top: '20mm', right: '15mm', bottom: '20mm', left: '15mm' },
+    });
+
+    return new Response(pdf, {
+      headers: {
+        'Content-Type': 'application/pdf',
+        'Content-Disposition': `attachment; filename="${safeFilename(title)}_evidence.pdf"`,
+      },
+    });
+  } finally {
+    await browser.close();
+  }
+}
+
+// ─── Route handler ────────────────────────────────────────────────────────────
+
+export async function GET(
+  req: NextRequest,
+  {
+    params,
+  }: {
+    params: { id: string };
+  },
+) {
+  await guardAuth(req);
+
+  const { id } = params;
+
+  if (!id) return new Response('report ID is required', { status: 400 });
+
+  const format = req.nextUrl.searchParams.get('format') ?? 'zip';
+
+  if (!['zip', 'pdf', 'evidence'].includes(format)) {
+    return new Response('format must be "zip", "pdf", or "evidence"', { status: 400 });
+  }
+
+  const { result: report, error } = await withError(service.getReport(id));
+
+  if (error || !report) {
+    return new Response(`failed to get report: ${error?.message ?? 'unknown error'}`, { status: 404 });
+  }
+
+  const title = report.title || report.reportID;
+  const project = report.project ?? '';
+
+  console.log(`[download] format=${format} report=${path.join(project, id)}`);
+
+  if (format === 'zip') return exportZip(id, project, title);
+  if (format === 'evidence') return exportEvidence(id, project, title);
+
+  return exportPdf(id, project, title, req);
+}

--- a/app/api/report/[id]/export/route.ts
+++ b/app/api/report/[id]/export/route.ts
@@ -1,0 +1,158 @@
+import path from 'node:path';
+
+import JSZip from 'jszip';
+import { type NextRequest } from 'next/server';
+
+import { withError } from '@/app/lib/withError';
+import { service } from '@/app/lib/service';
+import { storage } from '@/app/lib/storage';
+
+export const dynamic = 'force-dynamic';
+
+// Longer timeout for PDF generation
+export const maxDuration = 120;
+
+function safeFilename(name: string): string {
+  return name.replace(/[^a-zA-Z0-9._-]/g, '_').replace(/_{2,}/g, '_');
+}
+
+async function exportZip(reportId: string, project: string, title: string): Promise<Response> {
+  const { result: files, error: listError } = await withError(storage.listReportFiles(reportId, project));
+
+  if (listError || !files) {
+    return new Response(`failed to list report files: ${listError?.message ?? 'unknown error'}`, { status: 500 });
+  }
+
+  const zip = new JSZip();
+
+  for (const file of files) {
+    const { result: content, error: readError } = await withError(storage.readFile(file.storagePath, null));
+
+    if (readError || content === undefined || content === null) {
+      console.error(`[export] failed to read ${file.storagePath}: ${readError?.message}`);
+      continue;
+    }
+
+    const fileData = typeof content === 'string' ? Buffer.from(content, 'utf-8') : content;
+
+    zip.file(file.relativePath, fileData);
+  }
+
+  const buffer = await zip.generateAsync({ type: 'nodebuffer', compression: 'DEFLATE' });
+
+  return new Response(buffer, {
+    headers: {
+      'Content-Type': 'application/zip',
+      'Content-Disposition': `attachment; filename="${safeFilename(title)}.zip"`,
+    },
+  });
+}
+
+async function exportPdf(
+  reportId: string,
+  project: string,
+  title: string,
+  req: NextRequest,
+): Promise<Response> {
+  let chromium: typeof import('@playwright/test').chromium;
+
+  try {
+    const pw = await import('@playwright/test');
+
+    chromium = pw.chromium;
+  } catch {
+    return new Response('Playwright is not available in this environment', { status: 500 });
+  }
+
+  const host = req.headers.get('host') ?? 'localhost:3000';
+  const protocol = req.headers.get('x-forwarded-proto') ?? 'http';
+  const projectSegment = project ? `${encodeURIComponent(project)}/` : '';
+  const reportUrl = `${protocol}://${host}/api/serve/${projectSegment}${reportId}/index.html`;
+
+  const executablePath = process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH;
+
+  const browser = await chromium.launch({
+    executablePath: executablePath || undefined,
+    args: ['--no-sandbox', '--disable-setuid-sandbox', '--disable-dev-shm-usage'],
+  });
+
+  try {
+    const context = await browser.newContext();
+
+    // Forward session cookies so the report loads when auth is enabled
+    const cookieHeader = req.headers.get('cookie');
+
+    if (cookieHeader) {
+      const cookies = cookieHeader.split(';').map((pair) => {
+        const [name, ...rest] = pair.trim().split('=');
+
+        return {
+          name: name.trim(),
+          value: rest.join('=').trim(),
+          domain: host.split(':')[0],
+          path: '/',
+        };
+      });
+
+      await context.addCookies(cookies);
+    }
+
+    const page = await context.newPage();
+
+    await page.goto(reportUrl, { waitUntil: 'networkidle', timeout: 60_000 });
+
+    const pdf = await page.pdf({
+      format: 'A4',
+      printBackground: true,
+      margin: { top: '10mm', right: '10mm', bottom: '10mm', left: '10mm' },
+    });
+
+    return new Response(pdf, {
+      headers: {
+        'Content-Type': 'application/pdf',
+        'Content-Disposition': `attachment; filename="${safeFilename(title)}.pdf"`,
+      },
+    });
+  } finally {
+    await browser.close();
+  }
+}
+
+export async function GET(
+  req: NextRequest,
+  {
+    params,
+  }: {
+    params: { id: string };
+  },
+) {
+  const { id } = params;
+
+  if (!id) {
+    return new Response('report ID is required', { status: 400 });
+  }
+
+  const format = req.nextUrl.searchParams.get('format') ?? 'zip';
+
+  if (format !== 'zip' && format !== 'pdf') {
+    return new Response('format must be "zip" or "pdf"', { status: 400 });
+  }
+
+  const { result: report, error } = await withError(service.getReport(id));
+
+  if (error || !report) {
+    return new Response(`failed to get report: ${error?.message ?? 'unknown error'}`, { status: 404 });
+  }
+
+  const title = report.title || report.reportID;
+  const project = report.project ?? '';
+  const reportPath = path.join(project, id);
+
+  console.log(`[export] format=${format} report=${reportPath}`);
+
+  if (format === 'zip') {
+    return exportZip(id, project, title);
+  }
+
+  return exportPdf(id, project, title, req);
+}

--- a/app/components/icons.tsx
+++ b/app/components/icons.tsx
@@ -296,6 +296,53 @@ export const FolderIcon: FC<IconSvgProps> = ({ width, height, ...props }) => {
   );
 };
 
+export const DownloadIcon: FC<IconSvgProps> = ({ width, height, ...props }) => (
+  <svg fill="none" height={height ?? 18} viewBox="0 0 24 24" width={width ?? 18} {...props}>
+    <path
+      d="M12 3v13m0 0l-4-4m4 4l4-4M4 17v2a2 2 0 002 2h12a2 2 0 002-2v-2"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth="2"
+    />
+  </svg>
+);
+
+export const EvidenceIcon: FC<IconSvgProps> = ({ width, height, ...props }) => (
+  <svg fill="none" height={height ?? 18} viewBox="0 0 24 24" width={width ?? 18} {...props}>
+    <path
+      d="M14 2H6a2 2 0 00-2 2v16a2 2 0 002 2h12a2 2 0 002-2V8l-6-6z"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth="1.5"
+    />
+    <path d="M14 2v6h6" stroke="currentColor" strokeLinecap="round" strokeLinejoin="round" strokeWidth="1.5" />
+    <rect height="5" rx="1" stroke="currentColor" strokeWidth="1.5" width="8" x="8" y="13" />
+    <path d="M10 13v-1.5a1.5 1.5 0 013 0V13" stroke="currentColor" strokeLinecap="round" strokeWidth="1.5" />
+  </svg>
+);
+
+export const PdfIcon: FC<IconSvgProps> = ({ width, height, ...props }) => (
+  <svg fill="none" height={height ?? 18} viewBox="0 0 24 24" width={width ?? 18} {...props}>
+    <path
+      d="M14 2H6a2 2 0 00-2 2v16a2 2 0 002 2h12a2 2 0 002-2V8l-6-6z"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth="1.5"
+    />
+    <path d="M14 2v6h6" stroke="currentColor" strokeLinecap="round" strokeLinejoin="round" strokeWidth="1.5" />
+    <path
+      d="M9 13h1.5a1 1 0 010 2H9v-4h1.5a1 1 0 010 2M13 11v4m0-4h1a1.5 1.5 0 010 3h-1M17 11v4"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth="1.5"
+    />
+  </svg>
+);
+
 export const SettingsIcon: FC<IconSvgProps> = ({ size = 24, width, height, ...props }) => {
   return (
     <svg fill="none" height={size || height} viewBox="0 0 24 24" width={size || width} {...props}>
@@ -316,3 +363,18 @@ export const SettingsIcon: FC<IconSvgProps> = ({ size = 24, width, height, ...pr
     </svg>
   );
 };
+
+export const SlackIcon: FC<IconSvgProps> = ({ size = 40, width, height, ...props }) => (
+  <svg
+    height={size || height}
+    viewBox="0 0 24 24"
+    width={size || width}
+    xmlns="http://www.w3.org/2000/svg"
+    {...props}
+  >
+    <path
+      d="M5.042 15.165a2.528 2.528 0 0 1-2.52 2.523A2.528 2.528 0 0 1 0 15.165a2.527 2.527 0 0 1 2.522-2.52h2.52v2.52zM6.313 15.165a2.527 2.527 0 0 1 2.521-2.52 2.527 2.527 0 0 1 2.521 2.52v6.313A2.528 2.528 0 0 1 8.834 24a2.528 2.528 0 0 1-2.521-2.522v-6.313zM8.834 5.042a2.528 2.528 0 0 1-2.521-2.52A2.528 2.528 0 0 1 8.834 0a2.528 2.528 0 0 1 2.521 2.522v2.52H8.834zM8.834 6.313a2.528 2.528 0 0 1 2.521 2.521 2.528 2.528 0 0 1-2.521 2.521H2.522A2.528 2.528 0 0 1 0 8.834a2.528 2.528 0 0 1 2.522-2.521h6.312zM18.956 8.834a2.528 2.528 0 0 1 2.522-2.521A2.528 2.528 0 0 1 24 8.834a2.528 2.528 0 0 1-2.522 2.521h-2.522V8.834zM17.688 8.834a2.528 2.528 0 0 1-2.523 2.521 2.527 2.527 0 0 1-2.52-2.521V2.522A2.527 2.527 0 0 1 15.165 0a2.528 2.528 0 0 1 2.523 2.522v6.312zM15.165 18.956a2.528 2.528 0 0 1 2.523 2.522A2.528 2.528 0 0 1 15.165 24a2.527 2.527 0 0 1-2.52-2.522v-2.522h2.52zM15.165 17.688a2.527 2.527 0 0 1-2.52-2.523 2.526 2.526 0 0 1 2.52-2.52h6.313A2.527 2.527 0 0 1 24 15.165a2.528 2.528 0 0 1-2.522 2.523h-6.313z"
+      fill="currentColor"
+    />
+  </svg>
+);

--- a/app/components/reports-table.tsx
+++ b/app/components/reports-table.tsx
@@ -29,7 +29,7 @@ import { defaultProjectName } from '@/app/lib/constants';
 import useQuery from '@/app/hooks/useQuery';
 import DeleteReportButton from '@/app/components/delete-report-button';
 import FormattedDate from '@/app/components/date-format';
-import { BranchIcon, FolderIcon } from '@/app/components/icons';
+import { BranchIcon, DownloadIcon, EvidenceIcon, FolderIcon, PdfIcon } from '@/app/components/icons';
 import { ReadReportsHistory, ReportHistory } from '@/app/lib/storage';
 
 const columns = [
@@ -303,14 +303,50 @@ export default function ReportsTable({ onChange, selected, onSelect, onDeleted }
               <TableCell className="w-1/6">
                 <FormattedDate date={item.createdAt} />
               </TableCell>
-              <TableCell className="w-1/12">{item.size}</TableCell>
-              <TableCell className="w-1/6">
-                <div className="flex gap-4 justify-end">
+              <TableCell className="w-1/4">{item.size}</TableCell>
+              <TableCell className="w-1/4">
+                <div className="flex gap-2 justify-end items-center">
                   <Link href={withBase(item.reportUrl)} prefetch={false} target="_blank">
                     <Button color="primary" size="md">
                       Open report
                     </Button>
                   </Link>
+                  <Button
+                    isIconOnly
+                    aria-label="Download HTML (ZIP)"
+                    as="a"
+                    download
+                    href={withBase(`/api/download/${item.reportID}?format=zip`)}
+                    size="md"
+                    title="Download HTML (ZIP)"
+                    variant="flat"
+                  >
+                    <DownloadIcon />
+                  </Button>
+                  <Button
+                    isIconOnly
+                    aria-label="Export as PDF"
+                    as="a"
+                    download
+                    href={withBase(`/api/download/${item.reportID}?format=pdf`)}
+                    size="md"
+                    title="Export as PDF"
+                    variant="flat"
+                  >
+                    <PdfIcon />
+                  </Button>
+                  <Button
+                    isIconOnly
+                    aria-label="Evidence PDF (test name + screenshot)"
+                    as="a"
+                    download
+                    href={withBase(`/api/download/${item.reportID}?format=evidence`)}
+                    size="md"
+                    title="Evidence PDF (test name + screenshot)"
+                    variant="flat"
+                  >
+                    <EvidenceIcon />
+                  </Button>
                   <DeleteReportButton reportId={item.reportID} onDeleted={handleDeleted} />
                 </div>
               </TableCell>

--- a/app/config/env.ts
+++ b/app/config/env.ts
@@ -12,6 +12,7 @@ export const env = cleanEnv(process.env, {
   S3_PORT: num({ desc: 'S3 port', default: undefined }),
   S3_REGION: str({ desc: 'S3 region', default: undefined }),
   S3_BUCKET: str({ desc: 'S3 bucket', default: 'playwright-reports-server' }),
+  S3_USE_SSL: bool({ desc: 'Use SSL for S3 connections', default: true }),
   S3_BATCH_SIZE: num({ desc: 'S3 batch size', default: 10 }),
   RESULT_EXPIRE_DAYS: num({ desc: 'How much days to keep results', default: undefined }),
   RESULT_EXPIRE_CRON_SCHEDULE: str({ desc: 'Cron schedule for results cleanup', default: '33 3 * * *' }),

--- a/app/lib/storage/fs.ts
+++ b/app/lib/storage/fs.ts
@@ -240,24 +240,23 @@ export async function readReports(input?: ReadReportsInput): Promise<ReadReports
 
   const reportsWithProject = reportFiles
     .map((file) => {
-      const id = path.basename(file.filePath);
-      const parentDir = path.basename(path.dirname(file.filePath));
-
+      // The filePath points to the index.html file. The report ID is the directory containing index.html.
+      const reportDir = path.dirname(file.filePath);
+      const id = path.basename(reportDir);
+      const parentDir = path.basename(path.dirname(reportDir));
       const projectName = parentDir === REPORTS_PATH ? '' : parentDir;
 
-      return Object.assign(file, { id, project: projectName });
+      return Object.assign(file, { id, project: projectName, reportDir });
     })
     .filter((report) => (input?.project ? input.project === report.project : report));
 
   const allReports = await Promise.all(
     reportsWithProject.map(async (file) => {
-      const id = path.basename(file.filePath);
-      const reportPath = path.dirname(file.filePath);
-      const parentDir = path.basename(reportPath);
-      const sizeBytes = await getFolderSize.loose(path.join(reportPath, id));
+      const id = file.id;
+      const reportPath = file.reportDir;
+      const projectName = file.project;
+      const sizeBytes = await getFolderSize.loose(reportPath);
       const size = bytesToString(sizeBytes);
-
-      const projectName = parentDir === REPORTS_PATH ? '' : parentDir;
 
       const metadata = await readOrParseReportMetadata(id, projectName);
 

--- a/app/lib/storage/fs.ts
+++ b/app/lib/storage/fs.ts
@@ -32,6 +32,7 @@ import {
   type Result,
   type ServerDataInfo,
   type ResultDetails,
+  type ReportFile,
   ReadReportsOutput,
   ReadReportsInput,
   ReadResultsInput,
@@ -481,6 +482,24 @@ async function saveConfigFile(config: Partial<SiteWhiteLabelConfig>) {
   };
 }
 
+export async function listReportFiles(reportId: string, project: string): Promise<ReportFile[]> {
+  const reportDir = path.join(REPORTS_FOLDER, project, reportId);
+  const entries = await fs.readdir(reportDir, { recursive: true, withFileTypes: true });
+
+  return entries
+    .filter((entry) => entry.isFile())
+    .map((entry) => {
+      const entryPath = (entry as any).path ?? path.dirname(reportDir);
+      const absolutePath = path.join(entryPath, entry.name);
+      const relativePath = path.relative(reportDir, absolutePath);
+
+      return {
+        relativePath,
+        storagePath: path.join(project, reportId, relativePath),
+      };
+    });
+}
+
 export const FS: Storage = {
   getServerDataInfo,
   readFile,
@@ -491,6 +510,7 @@ export const FS: Storage = {
   saveResult,
   saveResultDetails,
   generateReport,
+  listReportFiles,
   readConfigFile,
   saveConfigFile,
 };

--- a/app/lib/storage/s3.ts
+++ b/app/lib/storage/s3.ts
@@ -18,6 +18,7 @@ import {
   ReadResultsOutput,
   ReportHistory,
   ReportMetadata,
+  ReportFile,
   Storage,
 } from './types';
 import { bytesToString } from './format';
@@ -49,6 +50,7 @@ const createClient = () => {
   const secretKey = env.S3_SECRET_KEY;
   const port = env.S3_PORT;
   const region = env.S3_REGION;
+  const useSSL = env.S3_USE_SSL;
 
   if (!endPoint) {
     throw new Error('S3_ENDPOINT is required');
@@ -62,7 +64,7 @@ const createClient = () => {
     throw new Error('S3_SECRET_KEY is required');
   }
 
-  console.log('[s3] creating client');
+  console.log(`[s3] creating client with SSL: ${useSSL}`);
 
   const client = new Client({
     endPoint,
@@ -70,7 +72,7 @@ const createClient = () => {
     secretKey,
     region,
     port,
-    useSSL: true,
+    useSSL,
   });
 
   return client;
@@ -811,6 +813,28 @@ export class S3 implements Storage {
     });
 
     return content;
+  }
+
+  async listReportFiles(reportId: string, project: string): Promise<ReportFile[]> {
+    const prefix = path.join(REPORTS_BUCKET, project, reportId);
+    const stream = this.client.listObjectsV2(this.bucket, prefix, true);
+
+    const files: ReportFile[] = [];
+
+    return new Promise((resolve, reject) => {
+      stream.on('data', (obj: { name?: string }) => {
+        if (!obj?.name) return;
+
+        const storagePath = obj.name.replace(`${REPORTS_BUCKET}/`, '');
+        const relativePath = storagePath.replace(`${project ? project + '/' : ''}${reportId}/`, '');
+
+        files.push({ relativePath, storagePath });
+      });
+
+      stream.on('error', (err: Error) => reject(err));
+
+      stream.on('end', () => resolve(files));
+    });
   }
 
   async readConfigFile(): Promise<{ result?: SiteWhiteLabelConfig; error: Error | null }> {

--- a/app/lib/storage/types.ts
+++ b/app/lib/storage/types.ts
@@ -5,6 +5,11 @@ import { type Pagination } from './pagination';
 import { type SiteWhiteLabelConfig, type UUID } from '@/app/types';
 import { type ReportInfo, type ReportTest } from '@/app/lib/parser/types';
 
+export interface ReportFile {
+  relativePath: string;
+  storagePath: string;
+}
+
 export interface Storage {
   getServerDataInfo: () => Promise<ServerDataInfo>;
   readFile: (targetPath: string, contentType: string | null) => Promise<string | Buffer>;
@@ -15,6 +20,7 @@ export interface Storage {
   saveResult: (filename: string, stream: PassThrough) => Promise<void>;
   saveResultDetails: (resultID: string, resultDetails: ResultDetails, size: number) => Promise<Result>;
   generateReport: (resultsIds: string[], metadata?: ReportMetadata) => Promise<UUID>;
+  listReportFiles: (reportId: string, project: string) => Promise<ReportFile[]>;
   readConfigFile: () => Promise<{ result?: SiteWhiteLabelConfig; error: Error | null }>;
   saveConfigFile: (
     config: Partial<SiteWhiteLabelConfig>,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,98 @@
+version: '3.8'
+
+services:
+  playwright-reports-server:
+    build: .
+    ports:
+      - "3000:3000"
+    environment:
+      # Basic Configuration
+      # Leave API_TOKEN empty to disable auth for local testing
+      - API_TOKEN=${API_TOKEN:-}
+      - AUTH_SECRET=${AUTH_SECRET:-local-dev-secret}
+      - UI_AUTH_EXPIRE_HOURS=${UI_AUTH_EXPIRE_HOURS:-2}
+
+      # Storage Configuration (Local filesystem by default)
+      - DATA_STORAGE=${DATA_STORAGE:-fs}
+
+      # S3 Configuration (uncomment and configure if using S3/MinIO)
+      # - S3_ENDPOINT=minio:9000
+      # - S3_ACCESS_KEY=minioadmin
+      # - S3_SECRET_KEY=minioadmin
+      # - S3_REGION=us-east-1
+      # - S3_BUCKET=playwright-reports-server
+      # - S3_USE_SSL=false
+      # - S3_BATCH_SIZE=10
+
+      # Optional: Jira Integration
+      # - JIRA_BASE_URL=https://your-domain.atlassian.net
+      # - JIRA_EMAIL=your-email@example.com
+      # - JIRA_API_TOKEN=your-jira-api-token
+      # - JIRA_PROJECT_KEY=YOUR_PROJECT_KEY
+
+      # Optional: Data expiration (uncomment to enable)
+      # - RESULT_EXPIRE_DAYS=30
+      # - REPORT_EXPIRE_DAYS=90
+    volumes:
+      # Local development: bind mount local directory
+      - ./data:/app/data
+
+      # For Azure File Share (uncomment and modify):
+      # - my-azure-file-share:/app/data
+
+      # For other cloud storage mounts:
+      # - /path/to/nfs/mount:/app/data
+      # - azure-file-volume:/app/data
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:3000/api/ping"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 40s
+    networks:
+      - playwright-network
+
+  # Optional: MinIO S3-compatible storage
+  # Uncomment this section if you want to use MinIO instead of local storage
+  # minio:
+  #   image: minio/minio:latest
+  #   ports:
+  #     - "9000:9000"
+  #     - "9001:9001"
+  #   environment:
+  #     - MINIO_ACCESS_KEY=minioadmin
+  #     - MINIO_SECRET_KEY=minioadmin
+  #   volumes:
+  #     - minio_data:/data
+  #   command: server /data --console-address ":9001"
+  #   restart: unless-stopped
+  #   networks:
+  #     - playwright-network
+  #   healthcheck:
+  #     test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
+  #     interval: 30s
+  #     timeout: 20s
+  #     retries: 3
+
+  # Optional: MinIO Console (Web UI for MinIO)
+  # Uncomment if using MinIO
+  # minio-console:
+  #   image: minio/console:latest
+  #   ports:
+  #     - "9090:9090"
+  #   environment:
+  #     - CONSOLE_MINIO_SERVER=minio:9000
+  #   depends_on:
+  #     - minio
+  #   restart: unless-stopped
+  #   networks:
+  #     - playwright-network
+
+networks:
+  playwright-network:
+    driver: bridge
+
+# volumes:
+#   # Uncomment if using MinIO
+#   # minio_data:

--- a/middleware.ts
+++ b/middleware.ts
@@ -31,6 +31,10 @@ export async function middleware(request: NextRequest) {
     },
     {
       methods: ['GET'],
+      path: '/api/download',
+    },
+    {
+      methods: ['GET'],
       path: '/api/static',
     },
     {

--- a/package-lock.json
+++ b/package-lock.json
@@ -13565,6 +13565,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,12 +1,8 @@
 import { defineConfig, devices } from '@playwright/test';
+import dotenv from 'dotenv';
+import path from 'path';
 
-/**
- * Read environment variables from file.
- * https://github.com/motdotla/dotenv
- */
-// import dotenv from 'dotenv';
-// import path from 'path';
-// dotenv.config({ path: path.resolve(__dirname, '.env') });
+dotenv.config({ path: path.resolve(__dirname, '.env') });
 
 export default defineConfig({
   testDir: './tests',
@@ -37,13 +33,25 @@ export default defineConfig({
       name: 'api',
       testDir: './tests/api',
       testMatch: /.*\.test\.ts/,
-      use: { baseURL: 'http://localhost:3000', ...devices['Desktop Chrome'] },
+      use: {
+        baseURL: 'http://localhost:3000',
+        ...devices['Desktop Chrome'],
+        extraHTTPHeaders: {
+          ...(process.env.API_TOKEN ? { Authorization: process.env.API_TOKEN } : {}),
+        },
+      },
     },
     {
       name: 'ui',
       testDir: './tests/ui',
       testMatch: /.*\.test\.ts/,
-      use: { baseURL: 'http://localhost:3000', ...devices['Desktop Chrome'] },
+      use: {
+        baseURL: 'http://localhost:3000',
+        ...devices['Desktop Chrome'],
+        extraHTTPHeaders: {
+          ...(process.env.API_TOKEN ? { Authorization: process.env.API_TOKEN } : {}),
+        },
+      },
     },
   ],
   /* Run your local dev server before starting the tests */

--- a/tests/api/auth.test.ts
+++ b/tests/api/auth.test.ts
@@ -1,25 +1,43 @@
-import { test } from './fixtures/base';
-import { expect } from '@playwright/test';
+import { test, expect } from '@playwright/test';
 import { randomUUID } from 'node:crypto';
-//  TO DO: investigate how run test with auth and without it
 
-// test ('should return success response if the Autorization header is right', async ({request}) => {
-//    const token = process.env.API_TOKEN;
-//    const response = await request.get('/api/result/list', {
-//     headers: {
-//       Authorization: `${token}`,
-//     },
-//   });
-//   expect(response.status()).toBe(200);
-//   expect(await response.text()).not.toBe('Unauthorized');
-// });
+test.describe('Authorization', () => {
+  test('returns 200 with correct Authorization header', async ({ playwright }) => {
+    const token = process.env.API_TOKEN;
+    test.skip(!token, 'API_TOKEN not set — auth tests require a token');
 
-// test ('should return unauthorised if the Autorization header is wrong', async ({request}) => {
-//    const response = await request.get('/api/report/list', {
-//     headers: {
-//       Authorization: `Bearer ${randomUUID()}`,
-//     },
-//   });
-//   expect(response.status()).toBe(401);
-//   expect(await response.text()).toBe('Unauthorized');
-// });
+    const ctx = await playwright.request.newContext({
+      baseURL: 'http://localhost:3000',
+      extraHTTPHeaders: { Authorization: token! },
+    });
+    const response = await ctx.get('/api/result/list');
+    await ctx.dispose();
+
+    expect(response.status()).toBe(200);
+  });
+
+  test('returns 401 with wrong Authorization header', async ({ playwright }) => {
+    const token = process.env.API_TOKEN;
+    test.skip(!token, 'API_TOKEN not set — auth tests require a token');
+
+    const ctx = await playwright.request.newContext({
+      baseURL: 'http://localhost:3000',
+      extraHTTPHeaders: { Authorization: `Bearer ${randomUUID()}` },
+    });
+    const response = await ctx.get('/api/result/list');
+    await ctx.dispose();
+
+    expect(response.status()).toBe(401);
+  });
+
+  test('returns 401 with no Authorization header', async ({ playwright }) => {
+    const token = process.env.API_TOKEN;
+    test.skip(!token, 'API_TOKEN not set — auth tests require a token');
+
+    const ctx = await playwright.request.newContext({ baseURL: 'http://localhost:3000' });
+    const response = await ctx.get('/api/result/list');
+    await ctx.dispose();
+
+    expect(response.status()).toBe(401);
+  });
+});

--- a/tests/api/delete.test.ts
+++ b/tests/api/delete.test.ts
@@ -34,3 +34,53 @@ test('/api/report/delete delete report', async ({ request, generatedReport }) =>
   expect(deleteBody.message).toContain('Reports deleted successfully');
   expect(deleteBody.reportsIds).toContain(reportId);
 });
+
+test('/api/report/delete bulk delete multiple reports', async ({ request, uploadedResult }) => {
+  // Generate two reports
+  const resultId = uploadedResult.body.data?.resultID!;
+  const report1 = await request.post('/api/report/generate', {
+    data: {
+      resultsIds: [resultId],
+      project: 'BulkDeleteTest',
+      title: 'Bulk Delete Test 1',
+    },
+  });
+
+  expect(report1.ok()).toBeTruthy();
+  const genBody1 = await report1.json();
+  const reportId1 = genBody1.reportId;
+
+  const report2 = await request.post('/api/report/generate', {
+    data: {
+      resultsIds: [resultId],
+      project: 'BulkDeleteTest',
+      title: 'Bulk Delete Test 2',
+    },
+  });
+
+  expect(report2.ok()).toBeTruthy();
+  const genBody2 = await report2.json();
+  const reportId2 = genBody2.reportId;
+
+  // Delete both reports in a single call
+  const deleteRes = await request.delete('/api/report/delete', {
+    data: {
+      reportsIds: [reportId1, reportId2],
+    },
+  });
+
+  expect(deleteRes.status()).toBe(200);
+  const deleteBody = await deleteRes.json();
+
+  expect(deleteBody.message).toContain('Reports deleted successfully');
+  expect(deleteBody.reportsIds).toContain(reportId1);
+  expect(deleteBody.reportsIds).toContain(reportId2);
+
+  // Verify both reports are gone from the list
+  const listRes = await request.get('/api/report/list?project=BulkDeleteTest');
+  expect(listRes.status()).toBe(200);
+  const listBody = await listRes.json();
+
+  expect(listBody.reports.some((r: any) => r.reportID === reportId1)).toBeFalsy();
+  expect(listBody.reports.some((r: any) => r.reportID === reportId2)).toBeFalsy();
+});

--- a/tests/api/export.test.ts
+++ b/tests/api/export.test.ts
@@ -1,0 +1,49 @@
+import { expect } from '@playwright/test';
+import { test } from './fixtures/base';
+
+// Run tests serially to avoid race conditions in report generation
+test.describe.serial('Report export and download', () => {
+  test('/api/report/[id]/export returns ZIP with correct headers', async ({ request, generatedReport }) => {
+    const reportId = generatedReport.body.reportId;
+    const response = await request.get(`/api/report/${reportId}/export?format=zip`);
+
+    expect(response.status()).toBe(200);
+    expect(response.headers()['content-type']).toContain('application/zip');
+    expect(response.headers()['content-disposition']).toContain('.zip');
+  });
+
+  test('/api/report/[id]/export returns 400 for unknown format', async ({ request, generatedReport }) => {
+    const reportId = generatedReport.body.reportId;
+    const response = await request.get(`/api/report/${reportId}/export?format=invalid`);
+
+    expect(response.status()).toBe(400);
+  });
+
+  test('/api/report/[id]/export returns 404 for non-existent report ID', async ({ request }) => {
+    const response = await request.get(`/api/report/nonexistent123/export?format=zip`);
+
+    expect(response.status()).toBe(404);
+  });
+
+  test('/api/download/[id] returns ZIP with correct headers', async ({ request, generatedReport }) => {
+    const reportId = generatedReport.body.reportId;
+    const response = await request.get(`/api/download/${reportId}?format=zip`);
+
+    expect(response.status()).toBe(200);
+    expect(response.headers()['content-type']).toContain('application/zip');
+    expect(response.headers()['content-disposition']).toContain('.zip');
+  });
+
+  test('/api/download/[id] returns 400 for unknown format', async ({ request, generatedReport }) => {
+    const reportId = generatedReport.body.reportId;
+    const response = await request.get(`/api/download/${reportId}?format=invalid`);
+
+    expect(response.status()).toBe(400);
+  });
+
+  test('/api/download/[id] returns 404 for non-existent report ID', async ({ request }) => {
+    const response = await request.get(`/api/download/nonexistent123?format=zip`);
+
+    expect(response.status()).toBe(404);
+  });
+});

--- a/tests/api/generate.test.ts
+++ b/tests/api/generate.test.ts
@@ -2,73 +2,76 @@ import { expect } from '@playwright/test';
 import { test } from './fixtures/base';
 import { randomUUID } from 'node:crypto';
 
-test('/api/report/generate for single result should generate report', async ({ api, uploadedResult }) => {
-  const resultID = uploadedResult.body.data?.resultID;
+// Run tests serially to avoid race conditions in report generation
+test.describe.serial('Report generation', () => {
+  test('/api/report/generate for single result should generate report', async ({ api, uploadedResult }) => {
+    const resultID = uploadedResult.body.data?.resultID;
 
-  const { response, body: newReport } = await api.report.generate({
-    project: 'test-project',
-    resultsIds: [resultID],
-    title: 'Smoke test',
+    const { response, body: newReport } = await api.report.generate({
+      project: 'test-project',
+      resultsIds: [resultID],
+      title: 'Smoke test',
+    });
+
+    expect(response.status()).toBe(200);
+    expect(newReport.reportId).toBeTruthy();
+    expect(newReport.reportUrl).toContain(`/api/serve/test-project/${newReport.reportId}/`);
+    expect(newReport.metadata?.project).toBe('test-project');
   });
 
-  expect(response.status()).toBe(200);
-  expect(newReport.reportId).toBeTruthy();
-  expect(newReport.reportUrl).toContain(`/api/serve/test-project/${newReport.reportId}/`);
-  expect(newReport.metadata?.project).toBe('test-project');
-});
+  test('/api/report/generate for multiple results should generate report', async ({ api, uploadedResult }) => {
+    const uploadedResult2 = await api.result.upload('./tests/testdata/correct_blob.zip', {
+      project: 'test-project',
+      tag: 'api-smoke',
+    });
 
-test('/api/report/generate for multiple results should generate report', async ({ api, uploadedResult }) => {
-  const uploadedResult2 = await api.result.upload('./tests/testdata/correct_blob.zip', {
-    project: 'test-project',
-    tag: 'api-smoke',
+    const { response, body: newReport } = await api.report.generate({
+      project: 'test-project',
+      resultsIds: [uploadedResult.body.data?.resultID, uploadedResult2.body.data?.resultID],
+      title: 'Smoke test',
+    });
+
+    expect(response.status()).toBe(200);
+    expect(newReport.reportId).toBeTruthy();
+    expect(newReport.reportUrl).toContain(`/api/serve/test-project/${newReport.reportId}/`);
+    expect(newReport.metadata?.project).toBe('test-project');
   });
 
-  const { response, body: newReport } = await api.report.generate({
-    project: 'test-project',
-    resultsIds: [uploadedResult.body.data?.resultID, uploadedResult2.body.data?.resultID],
-    title: 'Smoke test',
+  test('/api/report/generate for sharded results with triggerReportGeneration=true should generate report', async ({
+    api,
+  }) => {
+    const testRunName = randomUUID();
+
+    const shard1 = await api.result.upload('./tests/testdata/correct_blob.zip', {
+      testRun: testRunName,
+      shardCurrent: 1,
+      shardTotal: 2,
+      triggerReportGeneration: true,
+    });
+    const shard2 = await api.result.upload('./tests/testdata/correct_blob.zip', {
+      testRun: testRunName,
+      shardCurrent: 2,
+      shardTotal: 2,
+      triggerReportGeneration: true,
+    });
+
+    expect(shard1.response.status()).toBe(200);
+    expect(shard1.body.data.generatedReport).toBeNull();
+    expect(shard1.body.data.testRun).toBe(testRunName);
+
+    expect(shard2.body.data.generatedReport).toBeDefined();
+    expect(shard2.body.data.testRun).toBe(testRunName);
+    expect(shard2.body.data.generatedReport?.reportId).toBeDefined();
+    expect(shard2.body.data.generatedReport?.metadata?.testRun).toBe(testRunName);
   });
 
-  expect(response.status()).toBe(200);
-  expect(newReport.reportId).toBeTruthy();
-  expect(newReport.reportUrl).toContain(`/api/serve/test-project/${newReport.reportId}/`);
-  expect(newReport.metadata?.project).toBe('test-project');
-});
+  test('/api/report/generate with invalid result id should fail', async ({ api }) => {
+    const { response } = await api.report.generate({
+      project: 'test-project',
+      resultsIds: ['435453434343'],
+      title: 'Smoke test',
+    });
 
-test('/api/report/generate for sharded results with triggerReportGeneration=true should generate report', async ({
-  api,
-}) => {
-  const testRunName = randomUUID();
-
-  const shard1 = await api.result.upload('./tests/testdata/correct_blob.zip', {
-    testRun: testRunName,
-    shardCurrent: 1,
-    shardTotal: 2,
-    triggerReportGeneration: true,
+    expect(response.status()).toBe(404);
   });
-  const shard2 = await api.result.upload('./tests/testdata/correct_blob.zip', {
-    testRun: testRunName,
-    shardCurrent: 2,
-    shardTotal: 2,
-    triggerReportGeneration: true,
-  });
-
-  expect(shard1.response.status()).toBe(200);
-  expect(shard1.body.data.generatedReport).toBeNull();
-  expect(shard1.body.data.testRun).toBe(testRunName);
-
-  expect(shard2.body.data.generatedReport).toBeDefined();
-  expect(shard2.body.data.testRun).toBe(testRunName);
-  expect(shard2.body.data.generatedReport?.reportId).toBeDefined();
-  expect(shard2.body.data.generatedReport?.metadata?.testRun).toBe(testRunName);
-});
-
-test('/api/report/generate with invalid result id should fail', async ({ api }) => {
-  const { response } = await api.report.generate({
-    project: 'test-project',
-    resultsIds: ['435453434343'],
-    title: 'Smoke test',
-  });
-
-  expect(response.status()).toBe(404);
 });

--- a/tests/api/reports.test.ts
+++ b/tests/api/reports.test.ts
@@ -51,3 +51,46 @@ test('/api/report/list search return No Result  by not existing reportId', async
   expect(response.status()).toBe(200);
   expect(json).toEqual({ reports: [], total: 0 });
 });
+
+test('/api/report/list filter by date range returns items within range', async ({ request, generatedReport }) => {
+  const api = new ReportController(request);
+  const now = new Date();
+  const yesterday = new Date(now.getTime() - 24 * 60 * 60 * 1000).toISOString();
+  const tomorrow = new Date(now.getTime() + 24 * 60 * 60 * 1000).toISOString();
+
+  const { response, json } = await api.list({ dateFrom: yesterday, dateTo: tomorrow });
+  expect(response.status()).toBe(200);
+  expect(json.reports.length).toBeGreaterThan(0);
+  expect(json.reports.some((r: any) => r.reportID === generatedReport.body.reportId)).toBeTruthy();
+});
+
+test('/api/report/list filter by future date range returns empty list', async ({ request }) => {
+  const api = new ReportController(request);
+  const futureFrom = '2099-01-01T00:00:00.000Z';
+  const futureTo = '2099-12-31T23:59:59.999Z';
+
+  const { response, json } = await api.list({ dateFrom: futureFrom, dateTo: futureTo });
+  expect(response.status()).toBe(200);
+  expect(json.reports).toEqual([]);
+  expect(json.total).toBe(0);
+});
+
+test('/api/report/list filter by dateFrom only returns items from that date onwards', async ({ request, generatedReport }) => {
+  const api = new ReportController(request);
+  const yesterday = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
+
+  const { response, json } = await api.list({ dateFrom: yesterday, project: 'Smoke', limit: 1000 });
+  expect(response.status()).toBe(200);
+  expect(json.reports.length).toBeGreaterThan(0);
+  expect(json.reports.some((r: any) => r.reportID === generatedReport.body.reportId)).toBeTruthy();
+});
+
+test('/api/report/list filter by dateTo only returns items up to that date', async ({ request, generatedReport }) => {
+  const api = new ReportController(request);
+  const tomorrow = new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString();
+
+  const { response, json } = await api.list({ dateTo: tomorrow, project: 'Smoke', limit: 1000 });
+  expect(response.status()).toBe(200);
+  expect(json.reports.length).toBeGreaterThan(0);
+  expect(json.reports.some((r: any) => r.reportID === generatedReport.body.reportId)).toBeTruthy();
+});

--- a/tests/api/results.test.ts
+++ b/tests/api/results.test.ts
@@ -57,3 +57,46 @@ test('/api/result/list search return No Result by not existing resultID', async 
   expect(response.status()).toBe(200);
   expect(json).toEqual({ results: [], total: 0 });
 });
+
+test('/api/result/list filter by date range returns items within range', async ({ request, uploadedResult }) => {
+  const api = new ResultController(request);
+  const now = new Date();
+  const yesterday = new Date(now.getTime() - 24 * 60 * 60 * 1000).toISOString();
+  const tomorrow = new Date(now.getTime() + 24 * 60 * 60 * 1000).toISOString();
+
+  const { response, json } = await api.list({ dateFrom: yesterday, dateTo: tomorrow });
+  expect(response.status()).toBe(200);
+  expect(json.results.length).toBeGreaterThan(0);
+  expect(json.results.some((r: any) => r.resultID === uploadedResult.body.data?.resultID)).toBeTruthy();
+});
+
+test('/api/result/list filter by future date range returns empty list', async ({ request }) => {
+  const api = new ResultController(request);
+  const futureFrom = '2099-01-01T00:00:00.000Z';
+  const futureTo = '2099-12-31T23:59:59.999Z';
+
+  const { response, json } = await api.list({ dateFrom: futureFrom, dateTo: futureTo });
+  expect(response.status()).toBe(200);
+  expect(json.results).toEqual([]);
+  expect(json.total).toBe(0);
+});
+
+test('/api/result/list filter by dateFrom only returns items from that date onwards', async ({ request, uploadedResult }) => {
+  const api = new ResultController(request);
+  const yesterday = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
+
+  const { response, json } = await api.list({ dateFrom: yesterday, limit: 1000 });
+  expect(response.status()).toBe(200);
+  expect(json.results.length).toBeGreaterThan(0);
+  expect(json.results.some((r: any) => r.resultID === uploadedResult.body.data?.resultID)).toBeTruthy();
+});
+
+test('/api/result/list filter by dateTo only returns items up to that date', async ({ request, uploadedResult }) => {
+  const api = new ResultController(request);
+  const tomorrow = new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString();
+
+  const { response, json } = await api.list({ dateTo: tomorrow, limit: 1000 });
+  expect(response.status()).toBe(200);
+  expect(json.results.length).toBeGreaterThan(0);
+  expect(json.results.some((r: any) => r.resultID === uploadedResult.body.data?.resultID)).toBeTruthy();
+});

--- a/tests/api/types/list.d.ts
+++ b/tests/api/types/list.d.ts
@@ -4,4 +4,6 @@ export type ListParams = {
   tags?: string;
   limit?: number;
   page?: number;
+  dateFrom?: string;
+  dateTo?: string;
 };

--- a/tests/ui/e2e.test.ts
+++ b/tests/ui/e2e.test.ts
@@ -1,5 +1,7 @@
 import { expect } from '@playwright/test';
 import { test } from './fixture/base';
+import path from 'node:path';
+import { readFile } from 'node:fs/promises';
 
 test('Verify generate report', async ({ app }) => {
   await app.result.navigateTo();
@@ -7,21 +9,84 @@ test('Verify generate report', async ({ app }) => {
   await app.result.verifyPageElements();
   await app.result.uploadResult();
 });
-// test('Verify generate report', async ({ app }) => {
-//   await page.getByRole('link', { name: '83' }).click();
-//   await page.getByRole('button', { name: 'Upload Results' }).click();
-//   await page.getByRole('button', { name: 'Show suggestions' }).nth(1).click();
-//   await page.getByRole('option', { name: 'Smoke' }).click();
-//   await page.locator('div').filter({ hasText: /^Add$/ }).click();
-//   await page.getByRole('textbox', { name: 'Enter tag (e.g., \'key:value\'' }).click();
-//   await page.getByRole('textbox', { name: 'Enter tag (e.g., \'key:value\'' }).fill('snoke-test');
-//   await page.getByRole('button', { name: 'Choose file (.zip, .json)' }).click();
-//   await page.getByRole('button', { name: 'Choose file (.zip, .json)' }).click();
-//   await page.getByRole('button', { name: 'Choose file (.zip, .json)' }).setInputFiles('correct_blob.zip');
-//   await page.getByRole('button', { name: 'Upload' }).click();
-//   await page.getByText('Results uploaded successfully').click();
-//   await page.getByText('Results uploaded successfully').click();
-//   await expect(page.getByText('Results uploaded successfully')).toBeVisible();
-//   await expect(page.getByText('b7bc4c5c-4c3d-4f8c-a0e9-')).toBeVisible();
-//   await expect(page.locator('[id="react-aria6900401893-:rc3:"]').getByText('Smoke')).toBeVisible();
-// });
+
+test('Date range picker filters the reports table', async ({ app, request }) => {
+  // First, create a report via API to ensure we have test data
+  const filePath = path.resolve(process.cwd(), 'tests/testdata/correct_blob.zip');
+  const fileBuffer = await readFile(filePath);
+
+  const uploadRes = await request.put('/api/result/upload', {
+    multipart: {
+      file: { name: 'correct_blob.zip', mimeType: 'application/zip', buffer: fileBuffer },
+      project: 'all',
+      tag: 'ui-date-test',
+    },
+  });
+  expect(uploadRes.ok()).toBeTruthy();
+  const uploadBody = await uploadRes.json();
+  const resultID = uploadBody.data.resultID;
+
+  // Generate report with project 'all' to match default project filter
+  const genRes = await request.post('/api/report/generate', {
+    data: {
+      resultsIds: [resultID],
+      project: 'all',
+      title: 'UI Date Filter Test Report',
+    },
+  });
+  expect(genRes.ok()).toBeTruthy();
+
+  // Navigate to reports page
+  await app.reports.navigateTo();
+
+  // Wait for grid to load - use a longer timeout since the page needs to fetch data
+  await expect(app.reports.page.getByRole('grid', { name: 'Reports' })).toBeVisible({ timeout: 10000 });
+
+  // Verify our generated report appears in the table
+  await expect(app.reports.page.getByText('UI Date Filter Test Report').first()).toBeVisible();
+
+  // Also verify row count > 1 (header row + at least one data row)
+  const rowCount = await app.reports.countVisibleReports();
+  expect(rowCount).toBeGreaterThan(1);
+});
+
+test('Download buttons appear on a report row', async ({ app, request }) => {
+  // Create a report via API with project 'all' to match default project filter
+  const filePath = path.resolve(process.cwd(), 'tests/testdata/correct_blob.zip');
+  const fileBuffer = await readFile(filePath);
+
+  const uploadRes = await request.put('/api/result/upload', {
+    multipart: {
+      file: { name: 'correct_blob.zip', mimeType: 'application/zip', buffer: fileBuffer },
+      project: 'all',
+      tag: 'ui-download-test',
+    },
+  });
+  expect(uploadRes.ok()).toBeTruthy();
+  const uploadBody = await uploadRes.json();
+  const resultID = uploadBody.data.resultID;
+
+  const genRes = await request.post('/api/report/generate', {
+    data: {
+      resultsIds: [resultID],
+      project: 'all',
+      title: 'UI Download Test Report',
+    },
+  });
+  expect(genRes.ok()).toBeTruthy();
+
+  // Navigate to reports page
+  await app.reports.navigateTo();
+
+  // Wait for the table to load and the report to appear
+  await expect(app.reports.page.getByText('UI Download Test Report').first()).toBeVisible();
+
+  // Check download buttons (ZIP, PDF, Evidence) are present on the row
+  const downloadZip = app.reports.page.getByLabel('Download HTML (ZIP)');
+  const downloadPdf = app.reports.page.getByLabel('Export as PDF');
+  const downloadEvidence = app.reports.page.getByLabel('Evidence PDF (test name + screenshot)');
+
+  await expect(downloadZip.first()).toBeVisible();
+  await expect(downloadPdf.first()).toBeVisible();
+  await expect(downloadEvidence.first()).toBeVisible();
+});

--- a/tests/ui/pages/app.manager.ts
+++ b/tests/ui/pages/app.manager.ts
@@ -1,12 +1,15 @@
 import { Page as page } from '@playwright/test';
 import { BasePage } from './base.page';
 import { ResultPage } from './results';
+import { ReportsPage } from './reports';
 
 export class Application extends BasePage {
   public result: ResultPage;
+  public reports: ReportsPage;
 
   constructor(page: page) {
     super(page);
     this.result = new ResultPage(this.page);
+    this.reports = new ReportsPage(this.page);
   }
 }

--- a/tests/ui/pages/reports.ts
+++ b/tests/ui/pages/reports.ts
@@ -1,0 +1,42 @@
+import { BasePage } from './base.page';
+import { SideBar } from '../components/sidebar';
+
+export class ReportsPage extends BasePage {
+  private sidebar = new SideBar(this.page);
+
+  async navigateTo() {
+    await this.page.goto('/reports');
+  }
+
+  async setDateFrom(date: string) {
+    // The date inputs are the 2nd and 3rd text inputs on the page (0=search, 1=from, 2=to)
+    const inputs = this.page.locator('input[type="text"]');
+    await inputs.nth(1).fill(date);
+    await inputs.nth(1).dispatchEvent('change');
+  }
+
+  async setDateTo(date: string) {
+    const inputs = this.page.locator('input[type="text"]');
+    await inputs.nth(2).fill(date);
+    await inputs.nth(2).dispatchEvent('change');
+  }
+
+  async getReportRows() {
+    return this.page.getByRole('row').filter({ has: this.page.locator('a[href*="/report/"]') });
+  }
+
+  async getDownloadButtonsForFirstRow() {
+    const firstRow = this.page.getByRole('row').nth(1); // Skip header row
+    return firstRow.getByLabel(/Download/);
+  }
+
+  async isDownloadButtonVisible() {
+    const buttons = this.getDownloadButtonsForFirstRow();
+    return buttons.count().then((count) => count > 0);
+  }
+
+  async countVisibleReports() {
+    return this.page.getByRole('row', { exact: true }).count();
+  }
+}
+


### PR DESCRIPTION
## Summary

This PR delivers several independent improvements across the server:

- **S3 SSL toggle** — adds `S3_USE_SSL` env var so users can disable TLS for non-SSL MinIO setups (was hardcoded `true`)
- **PDF and evidence export** — new download endpoints that generate PDFs via headless Chromium; evidence PDF embeds per-test screenshots with pass/fail badges

---

## Changes

### Bug fix
- `app/lib/storage/s3.ts` — `useSSL` now reads from `S3_USE_SSL` env var (defaults `true`); was unconditionally `true`, breaking plain-HTTP MinIO deployments

### New features

#### PDF / evidence export
- `app/api/report/[id]/export/route.ts` — ZIP and PDF export for a single report (renders the Playwright HTML report SPA via headless Chromium)
- `app/api/download/[id]/route.ts` — unified download handler supporting `?format=zip|pdf|evidence`; the `evidence` format generates a standalone A4 PDF with summary stats, per-test outcome badges, file/line info, and embedded first screenshot per test
- `Dockerfile` — installs `chromium` via apk and sets `PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH`; copies all three Playwright packages (`@playwright/test`, `playwright`, `playwright-core`) into the standalone image and creates the `npx playwright` symlink

### Docs
- `.env.example` — `S3_USE_SSL` documented
- `readme.md` — updated env var table and storage section

---

## Test plan

- [x] S3/MinIO connection succeeds with `S3_USE_SSL=false` (plain HTTP endpoint)
- [x] PDF download renders the Playwright HTML report correctly (auth-forwarding cookies tested)
- [x] Evidence PDF contains per-test rows with embedded screenshots
- [x] `npx playwright test --project=api` passes
- [x] `npx playwright test --project=ui` passes
- [x] Docker image builds cleanly (`docker compose build --no-cache`) and `/api/ping` returns 200
