### PR TITLE
feat(auth): add domain-restricted Google OAuth for the web UI

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,15 @@ AUTH_URL=http://localhost:3000
 API_TOKEN='my-api-token'
 UI_AUTH_EXPIRE_HOURS='2'
 
+# Google OAuth (optional)
+# When AUTH_GOOGLE_ENABLED=true the web UI switches to Google sign-in for users,
+# and only emails whose domain is listed in AUTH_ALLOWED_DOMAINS are allowed in.
+# API_TOKEN is still required and continues to gate programmatic /api/* clients.
+AUTH_GOOGLE_ENABLED=false
+AUTH_GOOGLE_CLIENT_ID=''
+AUTH_GOOGLE_CLIENT_SECRET=''
+AUTH_ALLOWED_DOMAINS='acme.com' # comma-separated, e.g. "acme.com,partner.com"
+
 # Storage details
 DATA_STORAGE=fs # could be s3 or azure
 

--- a/app/auth.ts
+++ b/app/auth.ts
@@ -2,11 +2,13 @@ import NextAuth from 'next-auth';
 import { NextAuthConfig } from 'next-auth';
 import { type User } from 'next-auth';
 import CredentialsProvider from 'next-auth/providers/credentials';
+import GoogleProvider from 'next-auth/providers/google';
 import jwt from 'jsonwebtoken';
 
 import { env } from './config/env';
 
 const useAuth = !!env.API_TOKEN;
+const useGoogleAuth = useAuth && env.AUTH_GOOGLE_ENABLED;
 
 // strictly recommended to specify via env var
 // Use a stable default secret when AUTH_SECRET is not set to avoid JWT decryption errors
@@ -16,6 +18,18 @@ const secret = env.AUTH_SECRET ?? 'default-secret-for-non-auth-mode';
 // session expiration for api token auth
 const expirationHours = env.UI_AUTH_EXPIRE_HOURS ? parseInt(env.UI_AUTH_EXPIRE_HOURS) : 2;
 const expirationSeconds = expirationHours * 60 * 60;
+
+const allowedDomains = (env.AUTH_ALLOWED_DOMAINS ?? '')
+  .split(',')
+  .map((d) => d.trim().toLowerCase())
+  .filter(Boolean);
+
+const isEmailDomainAllowed = (email: string | null | undefined): boolean => {
+  if (!email || allowedDomains.length === 0) return false;
+  const domain = email.split('@')[1]?.toLowerCase();
+
+  return !!domain && allowedDomains.includes(domain);
+};
 
 export const authConfig: NextAuthConfig = {
   secret,
@@ -65,6 +79,57 @@ export const authConfig: NextAuthConfig = {
   },
 };
 
+const googleConfig = {
+  secret,
+  providers: [
+    GoogleProvider({
+      clientId: env.AUTH_GOOGLE_CLIENT_ID,
+      clientSecret: env.AUTH_GOOGLE_CLIENT_SECRET,
+    }),
+  ],
+  callbacks: {
+    async signIn({ profile }) {
+      if (!profile?.email_verified) return false;
+
+      return isEmailDomainAllowed(profile.email);
+    },
+    async jwt({ token, user, profile }) {
+      // on first sign-in copy the verified profile fields onto the JWT,
+      // and stash the server-side API_TOKEN so UI fetches to /api/* keep working.
+      if (user) {
+        const email = profile?.email ?? user.email ?? token.email;
+        const name = profile?.name ?? user.name ?? token.name;
+        const picture = profile?.picture ?? user.image ?? token.picture;
+
+        token.name = name;
+        token.email = email;
+        token.picture = picture;
+        token.apiToken = env.API_TOKEN;
+        token.jwtToken = jwt.sign({ authorized: true, email }, secret);
+      }
+
+      return token;
+    },
+    async session({ session, token }) {
+      session.user.name = token.name as string;
+      session.user.email = token.email as string;
+      session.user.image = token.picture as string;
+      session.user.apiToken = token.apiToken as string;
+      session.user.jwtToken = token.jwtToken as string;
+
+      return session;
+    },
+  },
+  session: {
+    strategy: 'jwt',
+    maxAge: expirationSeconds,
+  },
+  trustHost: true,
+  pages: {
+    signIn: '/login',
+  },
+} satisfies NextAuthConfig;
+
 const getJwtStubToken = () => {
   return jwt.sign({ authorized: true }, secret);
 };
@@ -109,4 +174,6 @@ const noAuth = {
   secret,
 } satisfies NextAuthConfig;
 
-export const { handlers, auth, signIn, signOut } = NextAuth(useAuth ? authConfig : noAuth);
+const selectedConfig: NextAuthConfig = !useAuth ? noAuth : useGoogleAuth ? googleConfig : authConfig;
+
+export const { handlers, auth, signIn, signOut } = NextAuth(selectedConfig);

--- a/app/components/login-form.tsx
+++ b/app/components/login-form.tsx
@@ -7,16 +7,21 @@ import { getProviders, signIn, useSession } from 'next-auth/react';
 
 import { title } from '@/app/components/primitives';
 
+type ProvidersMap = Awaited<ReturnType<typeof getProviders>>;
+
 export default function LoginForm() {
   const [input, setInput] = useState('');
   const [error, setError] = useState('');
   const [isAutoSigningIn, setIsAutoSigningIn] = useState(true);
+  const [providers, setProviders] = useState<ProvidersMap | null>(null);
   const router = useRouter();
   const session = useSession();
   const searchParams = useSearchParams();
 
   const target = searchParams?.get('callbackUrl') ?? '/';
   const callbackUrl = decodeURI(target);
+  const errorParam = searchParams?.get('error');
+  const isAccessDenied = errorParam === 'AccessDenied';
 
   useEffect(() => {
     // redirect if already authenticated
@@ -28,9 +33,10 @@ export default function LoginForm() {
 
     // check if we can sign in automatically
     getProviders()
-      .then((providers) => {
+      .then((available) => {
+        setProviders(available);
         // if no api token required we can automatically sign user in
-        if (providers?.credentials.name === 'No Auth') {
+        if (available?.credentials?.name === 'No Auth') {
           return signIn('credentials', {
             redirect: false,
           }).then((response) => {
@@ -63,6 +69,29 @@ export default function LoginForm() {
   // Show spinner while session is loading or while auto-signing in
   if (session.status === 'loading' || isAutoSigningIn) {
     return <Spinner className="w-full" />;
+  }
+
+  if (providers?.google) {
+    return (
+      <div className="grid col-span-6 justify-center">
+        <h1 className={title()}>Login</h1>
+        <Card className="h-screen min-w-[340px] max-h-[250px] p-2 mt-10">
+          <CardHeader className="content-start max-h-14">
+            <p className="text-md">Sign in with your company Google account</p>
+          </CardHeader>
+          <CardBody className="min-w-full h-24">
+            {isAccessDenied && (
+              <p className="text-danger text-sm">Your email domain is not allowed to access this server.</p>
+            )}
+          </CardBody>
+          <CardFooter className="mt-5">
+            <Button className="w-full" color="primary" onPress={() => signIn('google', { callbackUrl })}>
+              Sign in with Google
+            </Button>
+          </CardFooter>
+        </Card>
+      </div>
+    );
   }
 
   return (

--- a/app/components/navbar.tsx
+++ b/app/components/navbar.tsx
@@ -19,6 +19,7 @@ import { subtitle } from './primitives';
 import { defaultConfig } from '@/app/lib/config';
 import { HeaderLinks } from '@/app/components/header-links';
 import { ThemeSwitch } from '@/app/components/theme-switch';
+import { UserGreeting } from '@/app/components/user-greeting';
 import { SiteWhiteLabelConfig } from '@/app/types';
 import useQuery from '@/app/hooks/useQuery';
 
@@ -64,19 +65,21 @@ export const Navbar: React.FC = () => {
       </NavbarContent>
 
       <NavbarContent className="hidden sm:flex basis-1/5 sm:basis-full" justify="end">
-        <NavbarItem className="hidden sm:flex gap-4">
+        <NavbarItem className="hidden sm:flex gap-4 items-center">
           {config && !isLoading ? (
             <HeaderLinks config={config} />
           ) : (
             <Skeleton className="sm:flex basis-1/5 sm:basis-full" />
           )}
           <ThemeSwitch />
+          <UserGreeting />
         </NavbarItem>
       </NavbarContent>
 
       {/* mobile view fallback */}
       <NavbarContent className="sm:hidden basis-1 !justify-end">
         <ThemeSwitch />
+        <UserGreeting />
         {!!config && <NavbarMenuToggle />}
       </NavbarContent>
 

--- a/app/components/user-greeting.tsx
+++ b/app/components/user-greeting.tsx
@@ -1,0 +1,29 @@
+'use client';
+
+import { Avatar, Button } from '@heroui/react';
+import { signOut, useSession } from 'next-auth/react';
+
+export const UserGreeting: React.FC = () => {
+  const { data: session, status } = useSession();
+
+  if (status !== 'authenticated') return null;
+
+  const name = session?.user?.name;
+  const email = session?.user?.email;
+  const image = session?.user?.image ?? undefined;
+  const displayName = name || email;
+
+  // In API-token mode there is no name/email on the session, so render nothing —
+  // the navbar looks identical to before for non-OAuth deployments.
+  if (!displayName) return null;
+
+  return (
+    <div className="flex items-center gap-3">
+      <Avatar alt={displayName} className="w-7 h-7 text-tiny" name={displayName} src={image} />
+      <span className="hidden md:inline text-sm text-default-700">Hi, {displayName}</span>
+      <Button size="sm" variant="flat" onPress={() => signOut({ callbackUrl: '/login' })}>
+        Sign out
+      </Button>
+    </div>
+  );
+};

--- a/app/config/env.ts
+++ b/app/config/env.ts
@@ -4,6 +4,22 @@ export const env = cleanEnv(process.env, {
   API_TOKEN: str({ desc: 'API token for authorization', default: undefined }),
   UI_AUTH_EXPIRE_HOURS: str({ desc: 'How much hours are allowed to keep auth session valid', default: '2' }),
   AUTH_SECRET: str({ desc: 'Secret for JWT', default: undefined }),
+  AUTH_GOOGLE_ENABLED: bool({
+    desc: 'When true, the web UI authenticates users via Google OAuth instead of the API token form. Requires API_TOKEN, AUTH_SECRET, AUTH_GOOGLE_CLIENT_ID, AUTH_GOOGLE_CLIENT_SECRET and AUTH_ALLOWED_DOMAINS to be set.',
+    default: false,
+  }),
+  AUTH_GOOGLE_CLIENT_ID: str({
+    desc: 'Google OAuth client ID (used when AUTH_GOOGLE_ENABLED=true)',
+    default: undefined,
+  }),
+  AUTH_GOOGLE_CLIENT_SECRET: str({
+    desc: 'Google OAuth client secret (used when AUTH_GOOGLE_ENABLED=true)',
+    default: undefined,
+  }),
+  AUTH_ALLOWED_DOMAINS: str({
+    desc: 'Comma-separated list of email domains allowed to sign in via Google, e.g. "acme.com,partner.com". Empty/unset rejects all sign-ins.',
+    default: undefined,
+  }),
   DATA_STORAGE: str({ desc: 'Where to store data', default: 'fs' }),
   USE_SERVER_CACHE: bool({ desc: 'Use server side indexed cache for backend queries', default: false }),
   S3_ENDPOINT: str({ desc: 'S3 endpoint', default: undefined }),

--- a/middleware.ts
+++ b/middleware.ts
@@ -10,6 +10,9 @@ export const config = {
 };
 
 export async function middleware(request: NextRequest) {
+  // API_TOKEN gates programmatic /api/* clients regardless of which UI auth mode
+  // is active. When AUTH_GOOGLE_ENABLED=true the auth.ts JWT callback transparently
+  // attaches API_TOKEN to the user's session so internal UI fetches keep matching here.
   const isAuthRequired = !!env.API_TOKEN;
 
   if (!isAuthRequired) {

--- a/next-auth.d.ts
+++ b/next-auth.d.ts
@@ -6,3 +6,10 @@ declare module 'next-auth' {
     jwtToken?: string;
   }
 }
+
+declare module 'next-auth/jwt' {
+  interface JWT {
+    apiToken?: string;
+    jwtToken?: string;
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -13887,7 +13887,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,


### PR DESCRIPTION
## Summary

Adds an opt-in Google sign-in path for the web UI alongside the existing API-token credentials flow. When `AUTH_GOOGLE_ENABLED=true` the login page shows a single "Sign in with Google" button and rejects any account whose email domain is not listed in `AUTH_ALLOWED_DOMAINS` (comma-separated). The existing `API_TOKEN` is still required and continues to gate programmatic `/api/*` clients; it is transparently attached to the user's session so internal UI fetches keep working. When `AUTH_GOOGLE_ENABLED` is unset, the existing API-token and no-auth flows are unchanged.

Also adds a navbar greeting + sign-out button visible only when the session carries a user name/email (i.e. Google mode), so existing API-token deployments look identical.

## New environment variables

| Var | Type | Default | Purpose |
|---|---|---|---|
| `AUTH_GOOGLE_ENABLED` | bool | `false` | Master toggle. When `true`, the web UI switches to Google OAuth and the API-token credentials provider is removed from the UI. |
| `AUTH_GOOGLE_CLIENT_ID` | string | — | Google OAuth client ID. Required when `AUTH_GOOGLE_ENABLED=true`. |
| `AUTH_GOOGLE_CLIENT_SECRET` | string | — | Google OAuth client secret. Required when `AUTH_GOOGLE_ENABLED=true`. |
| `AUTH_ALLOWED_DOMAINS` | string | — | Comma-separated list, e.g. `acme.com,partner.com`. Only Google sign-ins whose email domain matches an entry are accepted. Empty/unset = fail closed. |

`API_TOKEN` remains required when Google OAuth is on.

## Files changed

- `app/config/env.ts` + `.env.example` — new env vars.
- `app/auth.ts` — three-way mode select: `noAuth` (no `API_TOKEN`) → `googleConfig` (Google OAuth on) → `authConfig` (current API-token credentials). Google `signIn` callback rejects on `!profile.email_verified` or unlisted domain; `jwt`/`session` callbacks expose `name`/`email`/`image` and stash `env.API_TOKEN` on the JWT.
- `app/components/login-form.tsx` — when `getProviders()` returns `google`, renders a single "Sign in with Google" button; surfaces `?error=AccessDenied` inline. Existing API-token / no-auth paths untouched.
- `app/components/user-greeting.tsx` (new) + `navbar.tsx` — `useSession()`-driven avatar + "Hi, {name}" + sign-out. Renders nothing when the session has no name/email (so API-token deployments visually unchanged).
- `middleware.ts` — only a clarifying comment; gating logic unchanged.
- `next-auth.d.ts` — augments `next-auth/jwt` JWT with `apiToken` / `jwtToken`.

## Test plan

- [x] `npm install`, `npm run lint`, `npx tsc --noEmit`, `npm run build` all pass; no new warnings or errors.
- [x] `AUTH_GOOGLE_ENABLED=true` — `/api/auth/providers` shows only `google`; `/login` renders the Google button.
- [x] `/api/info` returns 401 without header and 200 with `Authorization: <API_TOKEN>` in both modes.
- [x] `AUTH_GOOGLE_ENABLED=false` — `/api/auth/providers` shows only `credentials` (API Token); original login form intact.
- [x] End-to-end Google sign-in flow with a real OAuth client and an allowed-domain account — greeting renders, sign-out clears the session.
- [ ] Domain rejection: signing in with a non-allowed-domain account redirects to `/login?error=AccessDenied` with the inline error (verified with the UI render path; reviewer is encouraged to repeat with a real out-of-domain Google account).

## Out of scope

- Per-user roles / authorization beyond domain matching.
- Persisting users to a database (sessions remain JWT-only).
- Additional OAuth providers (GitHub, Microsoft).