### PR TITLE
feat: sortable columns in Reports and Results tabs

### DIFF
--- a/app/api/report/list/route.ts
+++ b/app/api/report/list/route.ts
@@ -13,9 +13,11 @@ export async function GET(request: NextRequest) {
   const search = searchParams.get('search') ?? '';
   const dateFrom = searchParams.get('dateFrom') ?? undefined;
   const dateTo = searchParams.get('dateTo') ?? undefined;
+  const orderParam = searchParams.get('order');
+  const order = orderParam === 'asc' || orderParam === 'desc' ? orderParam : undefined;
 
   const { result: reports, error } = await withError(
-    service.getReports({ pagination, project, search, dateFrom, dateTo }),
+    service.getReports({ pagination, project, search, dateFrom, dateTo, order }),
   );
 
   if (error) {

--- a/app/api/report/list/route.ts
+++ b/app/api/report/list/route.ts
@@ -3,6 +3,7 @@ import { type NextRequest } from 'next/server';
 import { withError } from '@/app/lib/withError';
 import { parseFromRequest } from '@/app/lib/storage/pagination';
 import { service } from '@/app/lib/service';
+import { parseReportSortField } from '@/app/lib/storage/sort';
 
 export const dynamic = 'force-dynamic'; // defaults to auto
 
@@ -15,9 +16,10 @@ export async function GET(request: NextRequest) {
   const dateTo = searchParams.get('dateTo') ?? undefined;
   const orderParam = searchParams.get('order');
   const order = orderParam === 'asc' || orderParam === 'desc' ? orderParam : undefined;
+  const sortBy = parseReportSortField(searchParams.get('sortBy'));
 
   const { result: reports, error } = await withError(
-    service.getReports({ pagination, project, search, dateFrom, dateTo, order }),
+    service.getReports({ pagination, project, search, dateFrom, dateTo, order, sortBy }),
   );
 
   if (error) {

--- a/app/api/result/list/route.ts
+++ b/app/api/result/list/route.ts
@@ -14,9 +14,11 @@ export async function GET(request: NextRequest) {
   const search = searchParams.get('search') ?? '';
   const dateFrom = searchParams.get('dateFrom') ?? undefined;
   const dateTo = searchParams.get('dateTo') ?? undefined;
+  const orderParam = searchParams.get('order');
+  const order = orderParam === 'asc' || orderParam === 'desc' ? orderParam : undefined;
 
   const { result, error } = await withError(
-    service.getResults({ pagination, project, tags, search, dateFrom, dateTo }),
+    service.getResults({ pagination, project, tags, search, dateFrom, dateTo, order }),
   );
 
   if (error) {

--- a/app/api/result/list/route.ts
+++ b/app/api/result/list/route.ts
@@ -3,6 +3,7 @@ import { type NextRequest } from 'next/server';
 import { service } from '@/app/lib/service';
 import { withError } from '@/app/lib/withError';
 import { parseFromRequest } from '@/app/lib/storage/pagination';
+import { parseResultSortField } from '@/app/lib/storage/sort';
 
 export const dynamic = 'force-dynamic'; // defaults to auto
 
@@ -16,9 +17,10 @@ export async function GET(request: NextRequest) {
   const dateTo = searchParams.get('dateTo') ?? undefined;
   const orderParam = searchParams.get('order');
   const order = orderParam === 'asc' || orderParam === 'desc' ? orderParam : undefined;
+  const sortBy = parseResultSortField(searchParams.get('sortBy'));
 
   const { result, error } = await withError(
-    service.getResults({ pagination, project, tags, search, dateFrom, dateTo, order }),
+    service.getResults({ pagination, project, tags, search, dateFrom, dateTo, order, sortBy }),
   );
 
   if (error) {

--- a/app/components/reports-table.tsx
+++ b/app/components/reports-table.tsx
@@ -34,11 +34,11 @@ import { BranchIcon, DownloadIcon, EvidenceIcon, FolderIcon, PdfIcon } from '@/a
 import { ReadReportsHistory, ReportHistory } from '@/app/lib/storage';
 
 const columns = [
-  { name: 'Title', uid: 'title' },
-  { name: 'Project', uid: 'project' },
-  { name: 'Pass Rate', uid: 'passRate' },
+  { name: 'Title', uid: 'title', sortable: true },
+  { name: 'Project', uid: 'project', sortable: true },
+  { name: 'Pass Rate', uid: 'passRate', sortable: true },
   { name: 'Created at', uid: 'createdAt', sortable: true },
-  { name: 'Size', uid: 'size' },
+  { name: 'Size', uid: 'size', sortable: true },
   { name: '', uid: 'actions' },
 ];
 
@@ -136,6 +136,7 @@ export default function ReportsTable({ onChange, selected, onSelect, onDeleted }
     offset: ((page - 1) * rowsPerPage).toString(),
     project,
     order: sortDescriptor.direction === 'ascending' ? 'asc' : 'desc',
+    sortBy: String(sortDescriptor.column ?? 'createdAt'),
     ...(search.trim() && { search: search.trim() }),
     ...(dateFrom && { dateFrom }),
     ...(dateTo && { dateTo }),
@@ -148,7 +149,16 @@ export default function ReportsTable({ onChange, selected, onSelect, onDeleted }
     error,
     refetch,
   } = useQuery<ReadReportsHistory>(withQueryParams(reportListEndpoint, getQueryParams()), {
-    dependencies: [project, search, dateFrom, dateTo, rowsPerPage, page, sortDescriptor.direction],
+    dependencies: [
+      project,
+      search,
+      dateFrom,
+      dateTo,
+      rowsPerPage,
+      page,
+      sortDescriptor.direction,
+      sortDescriptor.column,
+    ],
     placeholderData: keepPreviousData,
   });
 

--- a/app/components/reports-table.tsx
+++ b/app/components/reports-table.tsx
@@ -14,6 +14,7 @@ import {
   LinkIcon,
   Chip,
   type Selection,
+  type SortDescriptor,
 } from '@heroui/react';
 import Link from 'next/link';
 import { keepPreviousData } from '@tanstack/react-query';
@@ -36,7 +37,7 @@ const columns = [
   { name: 'Title', uid: 'title' },
   { name: 'Project', uid: 'project' },
   { name: 'Pass Rate', uid: 'passRate' },
-  { name: 'Created at', uid: 'createdAt' },
+  { name: 'Created at', uid: 'createdAt', sortable: true },
   { name: 'Size', uid: 'size' },
   { name: '', uid: 'actions' },
 ];
@@ -125,11 +126,16 @@ export default function ReportsTable({ onChange, selected, onSelect, onDeleted }
   const [dateTo, setDateTo] = useState<string>('');
   const [page, setPage] = useState(1);
   const [rowsPerPage, setRowsPerPage] = useState(10);
+  const [sortDescriptor, setSortDescriptor] = useState<SortDescriptor>({
+    column: 'createdAt',
+    direction: 'descending',
+  });
 
   const getQueryParams = () => ({
     limit: rowsPerPage.toString(),
     offset: ((page - 1) * rowsPerPage).toString(),
     project,
+    order: sortDescriptor.direction === 'ascending' ? 'asc' : 'desc',
     ...(search.trim() && { search: search.trim() }),
     ...(dateFrom && { dateFrom }),
     ...(dateTo && { dateTo }),
@@ -142,7 +148,7 @@ export default function ReportsTable({ onChange, selected, onSelect, onDeleted }
     error,
     refetch,
   } = useQuery<ReadReportsHistory>(withQueryParams(reportListEndpoint, getQueryParams()), {
-    dependencies: [project, search, dateFrom, dateTo, rowsPerPage, page],
+    dependencies: [project, search, dateFrom, dateTo, rowsPerPage, page, sortDescriptor.direction],
     placeholderData: keepPreviousData,
   });
 
@@ -201,6 +207,11 @@ export default function ReportsTable({ onChange, selected, onSelect, onDeleted }
     setPage(1);
   }, []);
 
+  const onSortChange = useCallback((descriptor: SortDescriptor) => {
+    setSortDescriptor(descriptor);
+    setPage(1);
+  }, []);
+
   const pages = useMemo(() => {
     return total ? Math.ceil(total / rowsPerPage) : 0;
   }, [project, total, rowsPerPage]);
@@ -248,11 +259,17 @@ export default function ReportsTable({ onChange, selected, onSelect, onDeleted }
         radius="none"
         selectedKeys={selected}
         selectionMode="multiple"
+        sortDescriptor={sortDescriptor}
         onSelectionChange={onChangeSelect}
+        onSortChange={onSortChange}
       >
         <TableHeader columns={columns}>
           {(column) => (
-            <TableColumn key={column.uid} className="px-3 py-6 text-md text-black dark:text-white font-medium">
+            <TableColumn
+              key={column.uid}
+              allowsSorting={(column as { sortable?: boolean }).sortable}
+              className="px-3 py-6 text-md text-black dark:text-white font-medium"
+            >
               {column.name}
             </TableColumn>
           )}

--- a/app/components/results-table.tsx
+++ b/app/components/results-table.tsx
@@ -26,11 +26,11 @@ import { ReadResultsOutput, type Result } from '@/app/lib/storage';
 import DeleteResultsButton from '@/app/components/delete-results-button';
 
 const columns = [
-  { name: 'Result ID', uid: 'title' },
-  { name: 'Project', uid: 'project' },
+  { name: 'Result ID', uid: 'title', sortable: true },
+  { name: 'Project', uid: 'project', sortable: true },
   { name: 'Created at', uid: 'createdAt', sortable: true },
-  { name: 'Tags', uid: 'tags' },
-  { name: 'Size', uid: 'size' },
+  { name: 'Tags', uid: 'tags', sortable: true },
+  { name: 'Size', uid: 'size', sortable: true },
   { name: '', uid: 'actions' },
 ];
 
@@ -65,6 +65,7 @@ export default function ResultsTable({ onSelect, onDeleted, selected }: Readonly
     offset: ((page - 1) * rowsPerPage).toString(),
     project,
     order: sortDescriptor.direction === 'ascending' ? 'asc' : 'desc',
+    sortBy: String(sortDescriptor.column ?? 'createdAt'),
     ...(selectedTags.length > 0 && { tags: selectedTags.join(',') }),
     ...(search.trim() && { search: search.trim() }),
     ...(dateFrom && { dateFrom }),
@@ -78,7 +79,17 @@ export default function ResultsTable({ onSelect, onDeleted, selected }: Readonly
     error,
     refetch,
   } = useQuery<ReadResultsOutput>(withQueryParams(resultListEndpoint, getQueryParams()), {
-    dependencies: [project, selectedTags, search, dateFrom, dateTo, rowsPerPage, page, sortDescriptor.direction],
+    dependencies: [
+      project,
+      selectedTags,
+      search,
+      dateFrom,
+      dateTo,
+      rowsPerPage,
+      page,
+      sortDescriptor.direction,
+      sortDescriptor.column,
+    ],
     placeholderData: keepPreviousData,
   });
 

--- a/app/components/results-table.tsx
+++ b/app/components/results-table.tsx
@@ -10,6 +10,7 @@ import {
   TableCell,
   Chip,
   type Selection,
+  type SortDescriptor,
   Spinner,
   Pagination,
 } from '@heroui/react';
@@ -27,7 +28,7 @@ import DeleteResultsButton from '@/app/components/delete-results-button';
 const columns = [
   { name: 'Result ID', uid: 'title' },
   { name: 'Project', uid: 'project' },
-  { name: 'Created at', uid: 'createdAt' },
+  { name: 'Created at', uid: 'createdAt', sortable: true },
   { name: 'Tags', uid: 'tags' },
   { name: 'Size', uid: 'size' },
   { name: '', uid: 'actions' },
@@ -54,11 +55,16 @@ export default function ResultsTable({ onSelect, onDeleted, selected }: Readonly
   const [dateTo, setDateTo] = useState<string>('');
   const [page, setPage] = useState(1);
   const [rowsPerPage, setRowsPerPage] = useState(10);
+  const [sortDescriptor, setSortDescriptor] = useState<SortDescriptor>({
+    column: 'createdAt',
+    direction: 'descending',
+  });
 
   const getQueryParams = () => ({
     limit: rowsPerPage.toString(),
     offset: ((page - 1) * rowsPerPage).toString(),
     project,
+    order: sortDescriptor.direction === 'ascending' ? 'asc' : 'desc',
     ...(selectedTags.length > 0 && { tags: selectedTags.join(',') }),
     ...(search.trim() && { search: search.trim() }),
     ...(dateFrom && { dateFrom }),
@@ -72,7 +78,7 @@ export default function ResultsTable({ onSelect, onDeleted, selected }: Readonly
     error,
     refetch,
   } = useQuery<ReadResultsOutput>(withQueryParams(resultListEndpoint, getQueryParams()), {
-    dependencies: [project, selectedTags, search, dateFrom, dateTo, rowsPerPage, page],
+    dependencies: [project, selectedTags, search, dateFrom, dateTo, rowsPerPage, page, sortDescriptor.direction],
     placeholderData: keepPreviousData,
   });
 
@@ -115,6 +121,11 @@ export default function ResultsTable({ onSelect, onDeleted, selected }: Readonly
 
   const onDateToChange = useCallback((date: string) => {
     setDateTo(date);
+    setPage(1);
+  }, []);
+
+  const onSortChange = useCallback((descriptor: SortDescriptor) => {
+    setSortDescriptor(descriptor);
     setPage(1);
   }, []);
 
@@ -192,13 +203,16 @@ export default function ResultsTable({ onSelect, onDeleted, selected }: Readonly
         radius="none"
         selectedKeys={selected}
         selectionMode="multiple"
+        sortDescriptor={sortDescriptor}
         onSelectionChange={onChangeSelect}
+        onSortChange={onSortChange}
       >
         <TableHeader columns={columns}>
           {(column) => (
             <TableColumn
               key={column.uid}
               align={column.uid === 'actions' ? 'center' : 'start'}
+              allowsSorting={(column as { sortable?: boolean }).sortable}
               className="px-3 py-6 text-md text-black dark:text-white font-medium"
             >
               {column.name}

--- a/app/lib/service/index.ts
+++ b/app/lib/service/index.ts
@@ -105,7 +105,9 @@ class Service {
         return date.getTime();
       };
 
-      reports.sort((a, b) => getTimestamp(b.createdAt) - getTimestamp(a.createdAt));
+      const dir = (input?.order ?? 'desc') === 'asc' ? 1 : -1;
+
+      reports.sort((a, b) => dir * (getTimestamp(a.createdAt) - getTimestamp(b.createdAt)));
       const currentReports = handlePagination<ReportHistory>(reports, input?.pagination);
 
       return {
@@ -241,7 +243,9 @@ class Service {
       return date.getTime();
     };
 
-    cached.sort((a, b) => getTimestamp(b.createdAt) - getTimestamp(a.createdAt));
+    const dir = (input?.order ?? 'desc') === 'asc' ? 1 : -1;
+
+    cached.sort((a, b) => dir * (getTimestamp(a.createdAt) - getTimestamp(b.createdAt)));
 
     let filtered = input?.project
       ? cached.filter((file) => (input?.project ? file.project === input.project : file))

--- a/app/lib/service/index.ts
+++ b/app/lib/service/index.ts
@@ -19,6 +19,7 @@ import {
   storage,
 } from '@/app/lib/storage';
 import { handlePagination } from '@/app/lib/storage/pagination';
+import { compareReports, compareResults } from '@/app/lib/storage/sort';
 import { SiteWhiteLabelConfig } from '@/app/types';
 import { defaultConfig } from '@/app/lib/config';
 import { env } from '@/app/config/env';
@@ -98,16 +99,10 @@ class Service {
         });
       }
 
-      const getTimestamp = (date?: Date | string) => {
-        if (!date) return 0;
-        if (typeof date === 'string') return new Date(date).getTime();
+      const sortField = input?.sortBy ?? 'createdAt';
+      const sortOrder = input?.order ?? 'desc';
 
-        return date.getTime();
-      };
-
-      const dir = (input?.order ?? 'desc') === 'asc' ? 1 : -1;
-
-      reports.sort((a, b) => dir * (getTimestamp(a.createdAt) - getTimestamp(b.createdAt)));
+      reports.sort((a, b) => compareReports(a, b, sortField, sortOrder));
       const currentReports = handlePagination<ReportHistory>(reports, input?.pagination);
 
       return {
@@ -243,10 +238,6 @@ class Service {
       return date.getTime();
     };
 
-    const dir = (input?.order ?? 'desc') === 'asc' ? 1 : -1;
-
-    cached.sort((a, b) => dir * (getTimestamp(a.createdAt) - getTimestamp(b.createdAt)));
-
     let filtered = input?.project
       ? cached.filter((file) => (input?.project ? file.project === input.project : file))
       : cached;
@@ -298,6 +289,11 @@ class Service {
         return searchableFields.some((field) => field?.toLowerCase().includes(searchTerm));
       });
     }
+
+    const sortField = input?.sortBy ?? 'createdAt';
+    const sortOrder = input?.order ?? 'desc';
+
+    filtered.sort((a, b) => compareResults(a, b, sortField, sortOrder));
 
     const results = !input?.pagination ? filtered : handlePagination(filtered, input?.pagination);
 

--- a/app/lib/storage/azure.ts
+++ b/app/lib/storage/azure.ts
@@ -254,7 +254,9 @@ export class AzureBlob implements Storage {
       return { results: [], total: 0 };
     }
 
-    jsonFiles.sort((a, b) => getTimestamp(b.lastModified) - getTimestamp(a.lastModified));
+    const resultsDir = (input?.order ?? 'desc') === 'asc' ? 1 : -1;
+
+    jsonFiles.sort((a, b) => resultsDir * (getTimestamp(a.lastModified) - getTimestamp(b.lastModified)));
 
     const noFilters = !input?.project && !input?.pagination;
     const resultFiles = noFilters ? handlePagination(jsonFiles, input?.pagination) : jsonFiles;
@@ -372,7 +374,9 @@ export class AzureBlob implements Storage {
       }
     }
 
-    reports.sort((a, b) => getTimestamp(b.createdAt) - getTimestamp(a.createdAt));
+    const reportsDir = (input?.order ?? 'desc') === 'asc' ? 1 : -1;
+
+    reports.sort((a, b) => reportsDir * (getTimestamp(a.createdAt) - getTimestamp(b.createdAt)));
 
     const currentReports = handlePagination<Report>(reports, input?.pagination);
     const withMetadata = await this.getReportsMetadata(currentReports as ReportHistory[]);

--- a/app/lib/storage/azure.ts
+++ b/app/lib/storage/azure.ts
@@ -40,6 +40,7 @@ import {
 } from './constants';
 import { handlePagination } from './pagination';
 import { getFileReportID } from './file';
+import { compareReports, compareResults } from './sort';
 
 import { parse } from '@/app/lib/parser';
 import { serveReportRoute } from '@/app/lib/constants';
@@ -317,18 +318,24 @@ export class AzureBlob implements Storage {
       });
     }
 
-    const currentFiles = noFilters ? results : handlePagination(filteredResults, input?.pagination);
+    const resultSortField = input?.sortBy ?? 'createdAt';
+    const resultSortOrder = input?.order ?? 'desc';
+    const enrichedResults: Result[] = (noFilters ? results : filteredResults).map((result) => {
+      const sizeBytes = resultSizes.get(result.resultID) ?? 0;
+
+      return {
+        ...result,
+        sizeBytes,
+        size: result.size ?? bytesToString(sizeBytes),
+      };
+    }) as Result[];
+
+    enrichedResults.sort((a, b) => compareResults(a, b, resultSortField, resultSortOrder));
+
+    const currentFiles = noFilters ? enrichedResults : handlePagination(enrichedResults, input?.pagination);
 
     return {
-      results: currentFiles.map((result) => {
-        const sizeBytes = resultSizes.get(result.resultID) ?? 0;
-
-        return {
-          ...result,
-          sizeBytes,
-          size: result.size ?? bytesToString(sizeBytes),
-        };
-      }) as Result[],
+      results: currentFiles,
       total: noFilters ? jsonFiles.length : filteredResults.length,
     };
   }
@@ -374,12 +381,14 @@ export class AzureBlob implements Storage {
       }
     }
 
-    const reportsDir = (input?.order ?? 'desc') === 'asc' ? 1 : -1;
+    const reportSortField = input?.sortBy ?? 'createdAt';
+    const reportSortOrder = input?.order ?? 'desc';
 
-    reports.sort((a, b) => reportsDir * (getTimestamp(a.createdAt) - getTimestamp(b.createdAt)));
+    reports.sort((a, b) => compareReports(a as ReportHistory, b as ReportHistory, 'createdAt', reportSortOrder));
 
-    const currentReports = handlePagination<Report>(reports, input?.pagination);
-    const withMetadata = await this.getReportsMetadata(currentReports as ReportHistory[]);
+    const canPrePaginate = reportSortField === 'createdAt';
+    const reportsForMetadata = canPrePaginate ? handlePagination<Report>(reports, input?.pagination) : reports;
+    const withMetadata = await this.getReportsMetadata(reportsForMetadata as ReportHistory[]);
 
     let filteredReports = withMetadata;
 
@@ -414,18 +423,22 @@ export class AzureBlob implements Storage {
       });
     }
 
+    filteredReports = filteredReports.map((report) => {
+      const sizeBytes = reportSizes.get(report.reportID) ?? 0;
+
+      return {
+        ...report,
+        sizeBytes,
+        size: bytesToString(sizeBytes),
+      };
+    });
+
+    filteredReports.sort((a, b) => compareReports(a, b, reportSortField, reportSortOrder));
+
     const finalReports = handlePagination(filteredReports, input?.pagination);
 
     return {
-      reports: finalReports.map((report) => {
-        const sizeBytes = reportSizes.get(report.reportID) ?? 0;
-
-        return {
-          ...report,
-          sizeBytes,
-          size: bytesToString(sizeBytes),
-        };
-      }),
+      reports: finalReports,
       total: filteredReports.length,
     };
   }

--- a/app/lib/storage/fs.ts
+++ b/app/lib/storage/fs.ts
@@ -21,6 +21,7 @@ import {
 import { processBatch } from './batch';
 import { handlePagination } from './pagination';
 import { createDirectory } from './folders';
+import { compareReports, compareResults } from './sort';
 
 import { defaultConfig, isConfigValid, noConfigErr } from '@/app/lib/config';
 import { parse } from '@/app/lib/parser';
@@ -175,17 +176,10 @@ export async function readResults(input?: ReadResultsInput) {
     });
   }
 
-  const getResultTimestamp = (date?: Date | string) => {
-    if (!date) return 0;
-    if (typeof date === 'string') return new Date(date).getTime();
+  const resultSortField = input?.sortBy ?? 'createdAt';
+  const resultSortOrder = input?.order ?? 'desc';
 
-    return date.getTime();
-  };
-  const resultsDir = (input?.order ?? 'desc') === 'asc' ? 1 : -1;
-
-  filteredResults.sort(
-    (a, b) => resultsDir * (getResultTimestamp(a.createdAt) - getResultTimestamp(b.createdAt)),
-  );
+  filteredResults.sort((a, b) => compareResults(a, b, resultSortField, resultSortOrder));
 
   const paginatedResults = handlePagination(filteredResults, input?.pagination);
 
@@ -337,15 +331,10 @@ export async function readReports(input?: ReadReportsInput): Promise<ReadReports
     });
   }
 
-  const getReportTimestamp = (date?: Date | string) => {
-    if (!date) return 0;
-    if (typeof date === 'string') return new Date(date).getTime();
+  const reportSortField = input?.sortBy ?? 'createdAt';
+  const reportSortOrder = input?.order ?? 'desc';
 
-    return date.getTime();
-  };
-  const reportsDir = (input?.order ?? 'desc') === 'asc' ? 1 : -1;
-
-  filteredReports.sort((a, b) => reportsDir * (getReportTimestamp(a.createdAt) - getReportTimestamp(b.createdAt)));
+  filteredReports.sort((a, b) => compareReports(a, b, reportSortField, reportSortOrder));
 
   const paginatedReports = handlePagination(filteredReports, input?.pagination);
 

--- a/app/lib/storage/fs.ts
+++ b/app/lib/storage/fs.ts
@@ -48,7 +48,8 @@ async function createDirectoriesIfMissing() {
 }
 
 function getRecursiveEntryPath(entry: Dirent): string {
-  const parentPath = (entry as Dirent & { path?: string }).path ?? '';
+  const e = entry as Dirent & { parentPath?: string; path?: string };
+  const parentPath = e.parentPath ?? e.path ?? '';
 
   return path.join(parentPath, entry.name);
 }
@@ -109,10 +110,8 @@ export async function readResults(input?: ReadResultsInput) {
     },
   );
 
-  const jsonFiles = stats.sort((a, b) => b.birthtimeMs - a.birthtimeMs);
-
   const fileContents: Result[] = await Promise.all(
-    jsonFiles.map(async (entry) => {
+    stats.map(async (entry) => {
       const content = await fs.readFile(entry.filePath, 'utf-8');
 
       return {
@@ -175,6 +174,18 @@ export async function readResults(input?: ReadResultsInput) {
       return resultTimestamp >= fromTimestamp && resultTimestamp <= toTimestamp;
     });
   }
+
+  const getResultTimestamp = (date?: Date | string) => {
+    if (!date) return 0;
+    if (typeof date === 'string') return new Date(date).getTime();
+
+    return date.getTime();
+  };
+  const resultsDir = (input?.order ?? 'desc') === 'asc' ? 1 : -1;
+
+  filteredResults.sort(
+    (a, b) => resultsDir * (getResultTimestamp(a.createdAt) - getResultTimestamp(b.createdAt)),
+  );
 
   const paginatedResults = handlePagination(filteredResults, input?.pagination);
 
@@ -249,9 +260,7 @@ export async function readReports(input?: ReadReportsInput): Promise<ReadReports
     },
   );
 
-  const reportFiles = stats.sort((a, b) => b.birthtimeMs - a.birthtimeMs);
-
-  const reportsWithProject = reportFiles
+  const reportsWithProject = stats
     .map((file) => {
       // The filePath points to the index.html file. The report ID is the directory containing index.html.
       const reportDir = path.dirname(file.filePath);
@@ -327,6 +336,16 @@ export async function readReports(input?: ReadReportsInput): Promise<ReadReports
       return reportTimestamp >= fromTimestamp && reportTimestamp <= toTimestamp;
     });
   }
+
+  const getReportTimestamp = (date?: Date | string) => {
+    if (!date) return 0;
+    if (typeof date === 'string') return new Date(date).getTime();
+
+    return date.getTime();
+  };
+  const reportsDir = (input?.order ?? 'desc') === 'asc' ? 1 : -1;
+
+  filteredReports.sort((a, b) => reportsDir * (getReportTimestamp(a.createdAt) - getReportTimestamp(b.createdAt)));
 
   const paginatedReports = handlePagination(filteredReports, input?.pagination);
 

--- a/app/lib/storage/s3.ts
+++ b/app/lib/storage/s3.ts
@@ -297,7 +297,9 @@ export class S3 implements Storage {
       return date.getTime();
     };
 
-    jsonFiles.sort((a, b) => getTimestamp(b.lastModified) - getTimestamp(a.lastModified));
+    const resultsDir = (input?.order ?? 'desc') === 'asc' ? 1 : -1;
+
+    jsonFiles.sort((a, b) => resultsDir * (getTimestamp(a.lastModified) - getTimestamp(b.lastModified)));
 
     // check if we can apply pagination early
     const noFilters = !input?.project && !input?.pagination;
@@ -451,7 +453,9 @@ export class S3 implements Storage {
           return date.getTime();
         };
 
-        reports.sort((a, b) => getTimestamp(b.createdAt) - getTimestamp(a.createdAt));
+        const reportsDir = (input?.order ?? 'desc') === 'asc' ? 1 : -1;
+
+        reports.sort((a, b) => reportsDir * (getTimestamp(a.createdAt) - getTimestamp(b.createdAt)));
 
         const currentReports = handlePagination<Report>(reports, input?.pagination);
 

--- a/app/lib/storage/s3.ts
+++ b/app/lib/storage/s3.ts
@@ -456,9 +456,7 @@ export class S3 implements Storage {
         const reportSortField = input?.sortBy ?? 'createdAt';
         const reportSortOrder = input?.order ?? 'desc';
 
-        reports.sort((a, b) =>
-          compareReports(a as ReportHistory, b as ReportHistory, 'createdAt', reportSortOrder),
-        );
+        reports.sort((a, b) => compareReports(a as ReportHistory, b as ReportHistory, 'createdAt', reportSortOrder));
 
         // When sorting by a metadata-only field we must load metadata for ALL reports before sorting & paginating.
         const canPrePaginate = reportSortField === 'createdAt';

--- a/app/lib/storage/s3.ts
+++ b/app/lib/storage/s3.ts
@@ -35,6 +35,7 @@ import {
 } from './constants';
 import { handlePagination } from './pagination';
 import { getFileReportID } from './file';
+import { compareReports, compareResults } from './sort';
 
 import { parse } from '@/app/lib/parser';
 import { serveReportRoute } from '@/app/lib/constants';
@@ -374,18 +375,24 @@ export class S3 implements Storage {
       });
     }
 
-    const currentFiles = noFilters ? results : handlePagination(filteredResults, input?.pagination);
+    const resultSortField = input?.sortBy ?? 'createdAt';
+    const resultSortOrder = input?.order ?? 'desc';
+    const enrichedResults: Result[] = (noFilters ? results : filteredResults).map((result) => {
+      const sizeBytes = resultSizes.get(result.resultID) ?? 0;
+
+      return {
+        ...result,
+        sizeBytes,
+        size: result.size ?? bytesToString(sizeBytes),
+      };
+    }) as Result[];
+
+    enrichedResults.sort((a, b) => compareResults(a, b, resultSortField, resultSortOrder));
+
+    const currentFiles = noFilters ? enrichedResults : handlePagination(enrichedResults, input?.pagination);
 
     return {
-      results: currentFiles.map((result) => {
-        const sizeBytes = resultSizes.get(result.resultID) ?? 0;
-
-        return {
-          ...result,
-          sizeBytes,
-          size: result.size ?? bytesToString(sizeBytes),
-        };
-      }) as Result[],
+      results: currentFiles,
       total: noFilters ? jsonFiles.length : filteredResults.length,
     };
   }
@@ -446,20 +453,18 @@ export class S3 implements Storage {
       });
 
       reportsStream.on('end', async () => {
-        const getTimestamp = (date?: Date | string) => {
-          if (!date) return 0;
-          if (typeof date === 'string') return new Date(date).getTime();
+        const reportSortField = input?.sortBy ?? 'createdAt';
+        const reportSortOrder = input?.order ?? 'desc';
 
-          return date.getTime();
-        };
+        reports.sort((a, b) =>
+          compareReports(a as ReportHistory, b as ReportHistory, 'createdAt', reportSortOrder),
+        );
 
-        const reportsDir = (input?.order ?? 'desc') === 'asc' ? 1 : -1;
+        // When sorting by a metadata-only field we must load metadata for ALL reports before sorting & paginating.
+        const canPrePaginate = reportSortField === 'createdAt';
+        const reportsForMetadata = canPrePaginate ? handlePagination<Report>(reports, input?.pagination) : reports;
 
-        reports.sort((a, b) => reportsDir * (getTimestamp(a.createdAt) - getTimestamp(b.createdAt)));
-
-        const currentReports = handlePagination<Report>(reports, input?.pagination);
-
-        const withMetadata = await this.getReportsMetadata(currentReports as ReportHistory[]);
+        const withMetadata = await this.getReportsMetadata(reportsForMetadata as ReportHistory[]);
 
         let filteredReports = withMetadata;
 
@@ -506,18 +511,22 @@ export class S3 implements Storage {
           });
         }
 
+        filteredReports = filteredReports.map((report) => {
+          const sizeBytes = reportSizes.get(report.reportID) ?? 0;
+
+          return {
+            ...report,
+            sizeBytes,
+            size: bytesToString(sizeBytes),
+          };
+        });
+
+        filteredReports.sort((a, b) => compareReports(a, b, reportSortField, reportSortOrder));
+
         const finalReports = handlePagination(filteredReports, input?.pagination);
 
         resolve({
-          reports: finalReports.map((report) => {
-            const sizeBytes = reportSizes.get(report.reportID) ?? 0;
-
-            return {
-              ...report,
-              sizeBytes,
-              size: bytesToString(sizeBytes),
-            };
-          }),
+          reports: finalReports,
           total: filteredReports.length,
         });
       });

--- a/app/lib/storage/sort.ts
+++ b/app/lib/storage/sort.ts
@@ -3,21 +3,9 @@ import { type Report, type Result, type ReportHistory, type SortOrder } from './
 export type ReportSortField = 'createdAt' | 'title' | 'project' | 'passRate' | 'size';
 export type ResultSortField = 'createdAt' | 'title' | 'project' | 'tags' | 'size';
 
-export const REPORT_SORT_FIELDS: readonly ReportSortField[] = [
-  'createdAt',
-  'title',
-  'project',
-  'passRate',
-  'size',
-];
+export const REPORT_SORT_FIELDS: readonly ReportSortField[] = ['createdAt', 'title', 'project', 'passRate', 'size'];
 
-export const RESULT_SORT_FIELDS: readonly ResultSortField[] = [
-  'createdAt',
-  'title',
-  'project',
-  'tags',
-  'size',
-];
+export const RESULT_SORT_FIELDS: readonly ResultSortField[] = ['createdAt', 'title', 'project', 'tags', 'size'];
 
 export const parseReportSortField = (value: string | null | undefined): ReportSortField | undefined =>
   (REPORT_SORT_FIELDS as readonly string[]).includes(value ?? '') ? (value as ReportSortField) : undefined;
@@ -100,12 +88,7 @@ export const compareReports = (
   return dir * compareValues(getReportSortValue(a, field), getReportSortValue(b, field));
 };
 
-export const compareResults = (
-  a: Result,
-  b: Result,
-  field: ResultSortField,
-  order: SortOrder,
-): number => {
+export const compareResults = (a: Result, b: Result, field: ResultSortField, order: SortOrder): number => {
   const dir = order === 'asc' ? 1 : -1;
 
   return dir * compareValues(getResultSortValue(a, field), getResultSortValue(b, field));
@@ -115,9 +98,5 @@ export const compareResults = (
 export const getTimestamp = toTimestamp;
 
 // Loose helper for the type-erased `Report` (used in storage layers where we sort before metadata merge in some backends).
-export const compareReportsLoose = (
-  a: Report,
-  b: Report,
-  field: ReportSortField,
-  order: SortOrder,
-): number => compareReports(a as ReportHistory, b as ReportHistory, field, order);
+export const compareReportsLoose = (a: Report, b: Report, field: ReportSortField, order: SortOrder): number =>
+  compareReports(a as ReportHistory, b as ReportHistory, field, order);

--- a/app/lib/storage/sort.ts
+++ b/app/lib/storage/sort.ts
@@ -1,0 +1,123 @@
+import { type Report, type Result, type ReportHistory, type SortOrder } from './types';
+
+export type ReportSortField = 'createdAt' | 'title' | 'project' | 'passRate' | 'size';
+export type ResultSortField = 'createdAt' | 'title' | 'project' | 'tags' | 'size';
+
+export const REPORT_SORT_FIELDS: readonly ReportSortField[] = [
+  'createdAt',
+  'title',
+  'project',
+  'passRate',
+  'size',
+];
+
+export const RESULT_SORT_FIELDS: readonly ResultSortField[] = [
+  'createdAt',
+  'title',
+  'project',
+  'tags',
+  'size',
+];
+
+export const parseReportSortField = (value: string | null | undefined): ReportSortField | undefined =>
+  (REPORT_SORT_FIELDS as readonly string[]).includes(value ?? '') ? (value as ReportSortField) : undefined;
+
+export const parseResultSortField = (value: string | null | undefined): ResultSortField | undefined =>
+  (RESULT_SORT_FIELDS as readonly string[]).includes(value ?? '') ? (value as ResultSortField) : undefined;
+
+const toTimestamp = (date?: Date | string) => {
+  if (!date) return 0;
+  if (typeof date === 'string') return new Date(date).getTime();
+
+  return date.getTime();
+};
+
+const RESULT_METADATA_EXCLUDE = ['resultID', 'title', 'createdAt', 'size', 'sizeBytes', 'project'];
+
+const resultTagsString = (item: Result): string =>
+  Object.entries(item)
+    .filter(([key]) => !RESULT_METADATA_EXCLUDE.includes(key))
+    .map(([key, value]) => `${key}: ${value}`)
+    .sort()
+    .join(', ')
+    .toLowerCase();
+
+const reportPassRate = (item: ReportHistory): number => {
+  const stats = item.stats;
+
+  if (!stats) return 0;
+  const total = (stats.expected ?? 0) + (stats.unexpected ?? 0) + (stats.flaky ?? 0) + (stats.skipped ?? 0);
+
+  if (total === 0) return 0;
+
+  return (stats.expected ?? 0) / total;
+};
+
+export const getReportSortValue = (item: ReportHistory, field: ReportSortField): number | string => {
+  switch (field) {
+    case 'createdAt':
+      return toTimestamp(item.createdAt);
+    case 'title':
+      return (item.title ?? item.reportID ?? '').toLowerCase();
+    case 'project':
+      return (item.project ?? '').toLowerCase();
+    case 'passRate':
+      return reportPassRate(item);
+    case 'size':
+      return item.sizeBytes ?? 0;
+  }
+};
+
+export const getResultSortValue = (item: Result, field: ResultSortField): number | string => {
+  switch (field) {
+    case 'createdAt':
+      return toTimestamp(item.createdAt);
+    case 'title':
+      return (item.title ?? item.resultID ?? '').toLowerCase();
+    case 'project':
+      return (item.project ?? '').toLowerCase();
+    case 'tags':
+      return resultTagsString(item);
+    case 'size':
+      return item.sizeBytes ?? 0;
+  }
+};
+
+const compareValues = (a: number | string, b: number | string): number => {
+  if (typeof a === 'number' && typeof b === 'number') return a - b;
+
+  return String(a).localeCompare(String(b));
+};
+
+export const compareReports = (
+  a: ReportHistory,
+  b: ReportHistory,
+  field: ReportSortField,
+  order: SortOrder,
+): number => {
+  const dir = order === 'asc' ? 1 : -1;
+
+  return dir * compareValues(getReportSortValue(a, field), getReportSortValue(b, field));
+};
+
+export const compareResults = (
+  a: Result,
+  b: Result,
+  field: ResultSortField,
+  order: SortOrder,
+): number => {
+  const dir = order === 'asc' ? 1 : -1;
+
+  return dir * compareValues(getResultSortValue(a, field), getResultSortValue(b, field));
+};
+
+// Re-export for callers that only need the timestamp helper.
+export const getTimestamp = toTimestamp;
+
+// Loose helper for the type-erased `Report` (used in storage layers where we sort before metadata merge in some backends).
+export const compareReportsLoose = (
+  a: Report,
+  b: Report,
+  field: ReportSortField,
+  order: SortOrder,
+): number => compareReports(a as ReportHistory, b as ReportHistory, field, order);

--- a/app/lib/storage/types.ts
+++ b/app/lib/storage/types.ts
@@ -27,6 +27,8 @@ export interface Storage {
   ) => Promise<{ result: SiteWhiteLabelConfig; error: Error | null }>;
 }
 
+export type SortOrder = 'asc' | 'desc';
+
 export interface ReadResultsInput {
   pagination?: Pagination;
   project?: string;
@@ -35,6 +37,7 @@ export interface ReadResultsInput {
   search?: string;
   dateFrom?: string;
   dateTo?: string;
+  order?: SortOrder;
 }
 
 export interface ReadResultsOutput {
@@ -49,6 +52,7 @@ export interface ReadReportsInput {
   search?: string;
   dateFrom?: string;
   dateTo?: string;
+  order?: SortOrder;
 }
 
 export interface ReadReportsOutput {

--- a/app/lib/storage/types.ts
+++ b/app/lib/storage/types.ts
@@ -38,6 +38,7 @@ export interface ReadResultsInput {
   dateFrom?: string;
   dateTo?: string;
   order?: SortOrder;
+  sortBy?: 'createdAt' | 'title' | 'project' | 'tags' | 'size';
 }
 
 export interface ReadResultsOutput {
@@ -53,6 +54,7 @@ export interface ReadReportsInput {
   dateFrom?: string;
   dateTo?: string;
   order?: SortOrder;
+  sortBy?: 'createdAt' | 'title' | 'project' | 'passRate' | 'size';
 }
 
 export interface ReadReportsOutput {

--- a/tests/api/reports.test.ts
+++ b/tests/api/reports.test.ts
@@ -97,3 +97,42 @@ test('/api/report/list filter by dateTo only returns items up to that date', asy
   expect(json.reports.length).toBeGreaterThan(0);
   expect(json.reports.some((r: any) => r.reportID === generatedReport.body.reportId)).toBeTruthy();
 });
+
+test('/api/report/list order=desc returns items newest first', async ({ request, generatedReport: _ }) => {
+  const api = new ReportController(request);
+  const { response, json } = await api.list({ order: 'desc', limit: 100 });
+  expect(response.status()).toBe(200);
+  expect(json.reports.length).toBeGreaterThan(0);
+  const timestamps = json.reports.map((r: any) => new Date(r.createdAt).getTime());
+  for (let i = 1; i < timestamps.length; i++) {
+    expect(timestamps[i]).toBeLessThanOrEqual(timestamps[i - 1]);
+  }
+});
+
+test('/api/report/list order=asc returns items oldest first', async ({ request, generatedReport: _ }) => {
+  const api = new ReportController(request);
+  const { response, json } = await api.list({ order: 'asc', limit: 100 });
+  expect(response.status()).toBe(200);
+  expect(json.reports.length).toBeGreaterThan(0);
+  const timestamps = json.reports.map((r: any) => new Date(r.createdAt).getTime());
+  for (let i = 1; i < timestamps.length; i++) {
+    expect(timestamps[i]).toBeGreaterThanOrEqual(timestamps[i - 1]);
+  }
+});
+
+test('/api/report/list default order matches order=desc', async ({ request, generatedReport: _ }) => {
+  const api = new ReportController(request);
+  const { json: defaultJson } = await api.list({ limit: 100 });
+  const { json: descJson } = await api.list({ order: 'desc', limit: 100 });
+  expect(defaultJson.reports.length).toBeGreaterThan(0);
+  expect(defaultJson.reports[0]?.reportID).toBe(descJson.reports[0]?.reportID);
+});
+
+test('/api/report/list invalid order falls back to default', async ({ request, generatedReport: _ }) => {
+  const api = new ReportController(request);
+  const { response, json: invalidJson } = await api.list({ order: 'garbage', limit: 100 });
+  const { json: defaultJson } = await api.list({ limit: 100 });
+  expect(response.status()).toBe(200);
+  expect(invalidJson.reports.length).toBeGreaterThan(0);
+  expect(invalidJson.reports[0]?.reportID).toBe(defaultJson.reports[0]?.reportID);
+});

--- a/tests/api/results.test.ts
+++ b/tests/api/results.test.ts
@@ -103,3 +103,42 @@ test('/api/result/list filter by dateTo only returns items up to that date', asy
   expect(json.results.length).toBeGreaterThan(0);
   expect(json.results.some((r: any) => r.resultID === uploadedResult.body.data?.resultID)).toBeTruthy();
 });
+
+test('/api/result/list order=desc returns items newest first', async ({ request, uploadedResult: _ }) => {
+  const api = new ResultController(request);
+  const { response, json } = await api.list({ order: 'desc', limit: 100 });
+  expect(response.status()).toBe(200);
+  expect(json.results.length).toBeGreaterThan(0);
+  const timestamps = json.results.map((r: any) => new Date(r.createdAt).getTime());
+  for (let i = 1; i < timestamps.length; i++) {
+    expect(timestamps[i]).toBeLessThanOrEqual(timestamps[i - 1]);
+  }
+});
+
+test('/api/result/list order=asc returns items oldest first', async ({ request, uploadedResult: _ }) => {
+  const api = new ResultController(request);
+  const { response, json } = await api.list({ order: 'asc', limit: 100 });
+  expect(response.status()).toBe(200);
+  expect(json.results.length).toBeGreaterThan(0);
+  const timestamps = json.results.map((r: any) => new Date(r.createdAt).getTime());
+  for (let i = 1; i < timestamps.length; i++) {
+    expect(timestamps[i]).toBeGreaterThanOrEqual(timestamps[i - 1]);
+  }
+});
+
+test('/api/result/list default order matches order=desc', async ({ request, uploadedResult: _ }) => {
+  const api = new ResultController(request);
+  const { json: defaultJson } = await api.list({ limit: 100 });
+  const { json: descJson } = await api.list({ order: 'desc', limit: 100 });
+  expect(defaultJson.results.length).toBeGreaterThan(0);
+  expect(defaultJson.results[0]?.resultID).toBe(descJson.results[0]?.resultID);
+});
+
+test('/api/result/list invalid order falls back to default', async ({ request, uploadedResult: _ }) => {
+  const api = new ResultController(request);
+  const { response, json: invalidJson } = await api.list({ order: 'garbage', limit: 100 });
+  const { json: defaultJson } = await api.list({ limit: 100 });
+  expect(response.status()).toBe(200);
+  expect(invalidJson.results.length).toBeGreaterThan(0);
+  expect(invalidJson.results[0]?.resultID).toBe(defaultJson.results[0]?.resultID);
+});

--- a/tests/api/types/list.d.ts
+++ b/tests/api/types/list.d.ts
@@ -7,4 +7,5 @@ export type ListParams = {
   dateFrom?: string;
   dateTo?: string;
   order?: 'asc' | 'desc' | string;
+  sortBy?: string;
 };

--- a/tests/api/types/list.d.ts
+++ b/tests/api/types/list.d.ts
@@ -6,4 +6,5 @@ export type ListParams = {
   page?: number;
   dateFrom?: string;
   dateTo?: string;
+  order?: 'asc' | 'desc' | string;
 };


### PR DESCRIPTION
## Summary

Adds user-controlled, server-side sorting to the **Reports** and **Results** dashboard tabs. Default behaviour is unchanged (newest first by `createdAt`); every non-action column header is now clickable to toggle ascending/descending.

- Click any column header → toggles sort for that column, resets pagination to page 1.
- API contract: `?sortBy=<field>&order=<asc|desc>`. Unknown values silently fall back to `createdAt` / `desc`, so existing callers are untouched.

## API

| Endpoint | Sortable fields |
|---|---|
| `GET /api/report/list` | `createdAt`, `title`, `project`, `passRate`, `size` |
| `GET /api/result/list` | `createdAt`, `title`, `project`, `tags`, `size` |

## Implementation notes

- New `app/lib/storage/sort.ts` is the single source of truth for sort comparators (`compareReports` / `compareResults`) and the per-entity `sortBy` allowlist. Numeric fields compare arithmetically; string fields use `localeCompare` on lowercased values; `passRate` is derived from `stats`; `tags` is the joined non-metadata key:value entries; `title` falls back to id.
- Service layer + all three storage backends (`fs`, `s3`, `azure`) now route through the shared comparator at the same point in their pipelines — after filtering, before pagination.
- For `s3` and `azure` `readReports`, the existing pre-pagination-then-load-metadata shortcut is preserved when `sortBy === 'createdAt'` (the default). For other `sortBy` values we load metadata for the full filtered set before sorting & paginating — otherwise sort-by-title etc. would silently pick the wrong page.
- `fs.ts` also: sort now operates on the merged record's `createdAt` instead of the file's `birthtimeMs`. This fixes a visible inconsistency when multiple reports share the same wall-clock second on disk — the displayed `createdAt` (sub-second from metadata) didn't agree with the sort key (whole-second `birthtimeMs`).
- `getRecursiveEntryPath` now reads `Dirent.parentPath` with `Dirent.path` as fallback. Node 20+ renamed the field; on Node 24 the old read returned `undefined`, producing `ENOENT: ... 'index.html'` 400s on the reports list.

## UI

- `<TableColumn allowsSorting>` on every sortable column.
- `<Table sortDescriptor onSortChange>` with state defaulted to `{ column: 'createdAt', direction: 'descending' }`, matching the current default.
- Sort changes are added to the `useQuery` dependency array so the request is re-issued and pagination resets to page 1.

## Test plan

- [x] API tests cover `order=asc`, `order=desc`, default (matches desc), and invalid order (falls back to desc) for both endpoints (`tests/api/reports.test.ts`, `tests/api/results.test.ts`).
- [x] `npx tsc --noEmit` clean (the only remaining errors are pre-existing in `tests/ui/e2e.test.ts`, unrelated).
- [x] Manual smoke against a local fs-backed dev server: every sortable field for both endpoints returns correctly ordered data on `order=asc`/`desc`; invalid `sortBy` falls back to `createdAt`; reports list no longer 400s on Node 24.
- [ ] Reviewer to verify s3/azure backends in their own deployment if applicable.