### PR TITLE
fix: format Created at dates using the browser's preferred locale

### DIFF
--- a/app/components/date-format.tsx
+++ b/app/components/date-format.tsx
@@ -9,7 +9,10 @@ export default function FormattedDate({ date }: { date: Date }) {
   const [formattedDate, setFormattedDate] = useState('');
 
   useEffect(() => {
-    setFormattedDate(new Date(date).toLocaleString());
+    // Follow the browser's preferred language (navigator.language) rather than the
+    // runtime default, which uses Chrome's UI/display language and falls back to
+    // en-US (American MM/DD/YYYY) regardless of the user's preferred-languages list.
+    setFormattedDate(new Date(date).toLocaleString(navigator.language));
   }, [date]);
 
   return <span>{formattedDate}</span>;


### PR DESCRIPTION
## Summary

The **Created at** column in the Reports and Results tables (and everywhere `FormattedDate` is used) was rendering dates in American format (`MM/DD/YYYY`) even for users whose browser is set to a non-US region.

Root cause: `FormattedDate` called `toLocaleString()` with **no locale argument**, so it uses the JS runtime's *default* locale. In Chrome that's tied to the **UI/display language**, not the user's *preferred-languages* list — and it falls back to `en-US`.

This passes `navigator.language` explicitly so dates follow the user's preferred language:
- `en-GB` → `05/06/2026, 14:30:00`
- `uk` → `05.06.2026, 14:30:00`
- `en-US` → `6/5/2026, 2:30:00 PM` (unchanged for US users)

`navigator.language` is read inside `useEffect`, which only runs client-side, so no SSR guard is needed.

## Change

```diff
-    setFormattedDate(new Date(date).toLocaleString());
+    setFormattedDate(new Date(date).toLocaleString(navigator.language));
```

## Test plan

- Set Chrome preferred language to English (UK) / Ukrainian, hard-reload the Reports and Results pages, and confirm the **Created at** values render as `DD/MM/YYYY` / `DD.MM.YYYY`.
- Verify US-English browsers are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)