### PR TITLE
Support file streaming.

### DIFF
--- a/app/api/serve/[[...filePath]]/route.ts
+++ b/app/api/serve/[[...filePath]]/route.ts
@@ -1,11 +1,12 @@
 import path from 'path';
+import { Readable } from 'node:stream';
 
 import mime from 'mime';
 import { type NextRequest, NextResponse } from 'next/server';
 import { redirect } from 'next/navigation';
 
 import { withError } from '@/app/lib/withError';
-import { storage } from '@/app/lib/storage';
+import { storage, type FileRange, type FileStreamResult } from '@/app/lib/storage';
 import { auth } from '@/app/auth';
 import { env } from '@/app/config/env';
 import { withBase } from '@/app/lib/url';
@@ -14,6 +15,45 @@ interface ReportParams {
   reportId: string;
   filePath?: string[];
 }
+
+/**
+ * Parse an HTTP Range header (e.g. "bytes=0-1023", "bytes=512-", "bytes=-256")
+ * into a {@link FileRange}. The backend resolves open-ended and suffix ranges
+ * against the file size. Returns null for a malformed / non-bytes range.
+ */
+function parseRangeHeader(rangeHeader: string): FileRange | null {
+  const match = rangeHeader.match(/^bytes=(\d*)-(\d*)$/);
+
+  if (!match) return null;
+
+  const [, rawStart, rawEnd] = match;
+
+  if (rawStart === '' && rawEnd === '') return null;
+
+  if (rawStart === '') {
+    return { suffixLength: parseInt(rawEnd, 10) };
+  }
+
+  return {
+    start: parseInt(rawStart, 10),
+    end: rawEnd === '' ? undefined : parseInt(rawEnd, 10),
+  };
+}
+
+/** Build a 200 (full) or 206 (partial) streaming response from a backend stream result. */
+function streamResponse(result: FileStreamResult, headers: Record<string, string>, partial: boolean): Response {
+  return new Response(Readable.toWeb(result.stream) as ReadableStream, {
+    status: partial ? 206 : 200,
+    headers: {
+      ...headers,
+      ...(partial ? { 'Content-Range': `bytes ${result.start}-${result.end}/${result.totalSize}` } : {}),
+      'Content-Length': String(result.contentLength),
+    },
+  });
+}
+
+const fileError = (error: Error | null, status = 404) =>
+  NextResponse.json({ error: `Could not read file ${error?.message ?? ''}` }, { status });
 
 export async function GET(
   req: NextRequest,
@@ -46,18 +86,55 @@ export async function GET(
     return NextResponse.next();
   }
 
+  const commonHeaders: Record<string, string> = {
+    'Content-Type': contentType ?? 'application/octet-stream',
+    'Accept-Ranges': 'bytes',
+    Authorization: `Bearer ${session?.user?.apiToken}`,
+  };
+
+  const rangeHeader = req.headers.get('range');
+  const range = rangeHeader ? parseRangeHeader(rangeHeader) : null;
+
+  // Ranged request — serve a single 206 partial response. Suffix ("bytes=-N") and
+  // open-ended ("bytes=X-") ranges are resolved against the file size by the backend.
+  if (range) {
+    const { result, error } = await withError(storage.readFileStream(targetPath, range));
+
+    if (error ?? !result) {
+      return fileError(error);
+    }
+
+    // Requested start is past the end of the file — Range Not Satisfiable.
+    if (range.start !== undefined && range.start > result.totalSize - 1) {
+      result.stream.destroy();
+
+      return new Response(null, {
+        status: 416,
+        headers: { ...commonHeaders, 'Content-Range': `bytes */${result.totalSize}` },
+      });
+    }
+
+    return streamResponse(result, commonHeaders, true);
+  }
+
+  // No Range header but it's a streamable type — stream the whole file rather than
+  // buffering it entirely into server memory.
+  if (contentType?.startsWith('video/')) {
+    const { result, error } = await withError(storage.readFileStream(targetPath));
+
+    if (error ?? !result) {
+      return fileError(error);
+    }
+
+    return streamResponse(result, commonHeaders, false);
+  }
+
+  // Default: buffered path (HTML, small assets, malformed Range headers).
   const { result: content, error } = await withError(storage.readFile(targetPath, contentType));
 
   if (error ?? !content) {
-    return NextResponse.json({ error: `Could not read file ${error?.message ?? ''}` }, { status: 404 });
+    return fileError(error);
   }
 
-  const headers = {
-    headers: {
-      'Content-Type': contentType ?? 'application/octet-stream',
-      Authorization: `Bearer ${session?.user?.apiToken}`,
-    },
-  };
-
-  return new Response(content, headers);
+  return new Response(content, { headers: commonHeaders });
 }

--- a/app/api/serve/[[...filePath]]/route.ts
+++ b/app/api/serve/[[...filePath]]/route.ts
@@ -6,7 +6,7 @@ import { type NextRequest, NextResponse } from 'next/server';
 import { redirect } from 'next/navigation';
 
 import { withError } from '@/app/lib/withError';
-import { storage, type FileRange, type FileStreamResult } from '@/app/lib/storage';
+import { storage, parseRangeHeader, type FileStreamResult } from '@/app/lib/storage';
 import { auth } from '@/app/auth';
 import { env } from '@/app/config/env';
 import { withBase } from '@/app/lib/url';
@@ -14,30 +14,6 @@ import { withBase } from '@/app/lib/url';
 interface ReportParams {
   reportId: string;
   filePath?: string[];
-}
-
-/**
- * Parse an HTTP Range header (e.g. "bytes=0-1023", "bytes=512-", "bytes=-256")
- * into a {@link FileRange}. The backend resolves open-ended and suffix ranges
- * against the file size. Returns null for a malformed / non-bytes range.
- */
-function parseRangeHeader(rangeHeader: string): FileRange | null {
-  const match = rangeHeader.match(/^bytes=(\d*)-(\d*)$/);
-
-  if (!match) return null;
-
-  const [, rawStart, rawEnd] = match;
-
-  if (rawStart === '' && rawEnd === '') return null;
-
-  if (rawStart === '') {
-    return { suffixLength: parseInt(rawEnd, 10) };
-  }
-
-  return {
-    start: parseInt(rawStart, 10),
-    end: rawEnd === '' ? undefined : parseInt(rawEnd, 10),
-  };
 }
 
 /** Build a 200 (full) or 206 (partial) streaming response from a backend stream result. */

--- a/app/lib/storage/azure.ts
+++ b/app/lib/storage/azure.ts
@@ -89,6 +89,7 @@ export class AzureBlob implements Storage {
 
   private constructor() {
     const { serviceClient, credential } = createClient();
+
     this.containerName = env.AZURE_CONTAINER;
     this.batchSize = env.AZURE_BATCH_SIZE;
     this.container = serviceClient.getContainerClient(this.containerName);
@@ -240,6 +241,12 @@ export class AzureBlob implements Storage {
     const totalSize = properties.contentLength ?? 0;
 
     const { start, end, contentLength } = resolveFileRange(totalSize, range);
+
+    // Unsatisfiable range (e.g. start past EOF): return an empty stream so the caller
+    // can respond 416 rather than issuing an invalid download request.
+    if (contentLength <= 0) {
+      return { stream: Readable.from([]), totalSize, start, end, contentLength };
+    }
 
     const downloadResponse = await blobClient.download(start, contentLength);
 

--- a/app/lib/storage/azure.ts
+++ b/app/lib/storage/azure.ts
@@ -25,6 +25,9 @@ import {
   ReportFile,
   ReportMetadata,
   Storage,
+  type FileRange,
+  type FileStreamResult,
+  resolveFileRange,
 } from './types';
 import { bytesToString } from './format';
 import {
@@ -39,7 +42,7 @@ import {
   DATA_FOLDER,
 } from './constants';
 import { handlePagination } from './pagination';
-import { getFileReportID } from './file';
+import { getFileReportID, getRemotePath } from './file';
 import { compareReports, compareResults } from './sort';
 
 import { parse } from '@/app/lib/parser';
@@ -132,7 +135,7 @@ export class AzureBlob implements Storage {
     await this.ensureContainerExists();
     console.log(`[azure] read ${targetPath}`);
 
-    const remotePath = targetPath.includes(REPORTS_BUCKET) ? targetPath : `${REPORTS_BUCKET}/${targetPath}`;
+    const remotePath = getRemotePath(targetPath);
 
     console.log(`[azure] reading from remote path: ${remotePath}`);
 
@@ -226,6 +229,27 @@ export class AzureBlob implements Storage {
     }
 
     return result!;
+  }
+
+  async readFileStream(targetPath: string, range?: FileRange): Promise<FileStreamResult> {
+    await this.ensureContainerExists();
+    const remotePath = getRemotePath(targetPath);
+
+    const blobClient = this.container.getBlobClient(remotePath);
+    const properties = await blobClient.getProperties();
+    const totalSize = properties.contentLength ?? 0;
+
+    const { start, end, contentLength } = resolveFileRange(totalSize, range);
+
+    const downloadResponse = await blobClient.download(start, contentLength);
+
+    if (!downloadResponse.readableStreamBody) {
+      throw new Error(`[azure] readFileStream: no readable stream body for ${remotePath}`);
+    }
+
+    const stream = downloadResponse.readableStreamBody as Readable;
+
+    return { stream, totalSize, start, end, contentLength };
   }
 
   async readResults(input?: ReadResultsInput): Promise<ReadResultsOutput> {

--- a/app/lib/storage/file.ts
+++ b/app/lib/storage/file.ts
@@ -4,6 +4,9 @@ export const isUUID = (uuid?: string): boolean => {
   return /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(uuid ?? '');
 };
 
+export const getRemotePath = (targetPath: string): string =>
+  targetPath.includes(REPORTS_BUCKET) ? targetPath : `${REPORTS_BUCKET}/${targetPath}`;
+
 export const getFileReportID = (filePath: string): string => {
   const parts = filePath.split(REPORTS_BUCKET).pop()?.split('/') ?? [];
 

--- a/app/lib/storage/fs.ts
+++ b/app/lib/storage/fs.ts
@@ -1,7 +1,7 @@
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import { randomUUID } from 'node:crypto';
-import { createWriteStream, type Dirent, type Stats } from 'node:fs';
+import { createReadStream, createWriteStream, type Dirent, type Stats } from 'node:fs';
 import { pipeline } from 'node:stream/promises';
 import { PassThrough } from 'node:stream';
 
@@ -34,6 +34,9 @@ import {
   type ServerDataInfo,
   type ResultDetails,
   type ReportFile,
+  type FileRange,
+  type FileStreamResult,
+  resolveFileRange,
   ReadReportsOutput,
   ReadReportsInput,
   ReadResultsInput,
@@ -82,6 +85,17 @@ export async function readFile(targetPath: string, contentType: string | null) {
   return await fs.readFile(path.join(REPORTS_FOLDER, targetPath), {
     encoding: contentType === 'text/html' ? 'utf-8' : null,
   });
+}
+
+export async function readFileStream(targetPath: string, range?: FileRange): Promise<FileStreamResult> {
+  const fullPath = path.join(REPORTS_FOLDER, targetPath);
+  const stat = await fs.stat(fullPath);
+  const totalSize = stat.size;
+
+  const { start, end, contentLength } = resolveFileRange(totalSize, range);
+  const stream = createReadStream(fullPath, { start, end });
+
+  return { stream, totalSize, start, end, contentLength };
 }
 
 async function getResultsCount() {
@@ -523,6 +537,7 @@ export async function listReportFiles(reportId: string, project: string): Promis
 export const FS: Storage = {
   getServerDataInfo,
   readFile,
+  readFileStream,
   readResults,
   readReports,
   deleteResults,

--- a/app/lib/storage/fs.ts
+++ b/app/lib/storage/fs.ts
@@ -3,7 +3,7 @@ import path from 'node:path';
 import { randomUUID } from 'node:crypto';
 import { createReadStream, createWriteStream, type Dirent, type Stats } from 'node:fs';
 import { pipeline } from 'node:stream/promises';
-import { PassThrough } from 'node:stream';
+import { PassThrough, Readable } from 'node:stream';
 
 import getFolderSize from 'get-folder-size';
 
@@ -93,7 +93,9 @@ export async function readFileStream(targetPath: string, range?: FileRange): Pro
   const totalSize = stat.size;
 
   const { start, end, contentLength } = resolveFileRange(totalSize, range);
-  const stream = createReadStream(fullPath, { start, end });
+  // Unsatisfiable range (e.g. start past EOF): return an empty stream so the caller
+  // can respond 416 rather than crashing on an invalid stream request.
+  const stream = contentLength <= 0 ? Readable.from([]) : createReadStream(fullPath, { start, end });
 
   return { stream, totalSize, start, end, contentLength };
 }

--- a/app/lib/storage/s3.ts
+++ b/app/lib/storage/s3.ts
@@ -255,7 +255,12 @@ export class S3 implements Storage {
 
     const { start, end, contentLength } = resolveFileRange(totalSize, range);
 
-    const stream = await this.client.getPartialObject(this.bucket, remotePath, start, contentLength);
+    // Unsatisfiable range (e.g. start past EOF): return an empty stream so the caller
+    // can respond 416 rather than issuing an invalid partial request.
+    const stream =
+      contentLength <= 0
+        ? Readable.from([])
+        : await this.client.getPartialObject(this.bucket, remotePath, start, contentLength);
 
     return { stream, totalSize, start, end, contentLength };
   }

--- a/app/lib/storage/s3.ts
+++ b/app/lib/storage/s3.ts
@@ -20,6 +20,9 @@ import {
   ReportMetadata,
   ReportFile,
   Storage,
+  type FileRange,
+  type FileStreamResult,
+  resolveFileRange,
 } from './types';
 import { bytesToString } from './format';
 import {
@@ -34,7 +37,7 @@ import {
   DATA_FOLDER,
 } from './constants';
 import { handlePagination } from './pagination';
-import { getFileReportID } from './file';
+import { getFileReportID, getRemotePath } from './file';
 import { compareReports, compareResults } from './sort';
 
 import { parse } from '@/app/lib/parser';
@@ -136,7 +139,7 @@ export class S3 implements Storage {
     await this.ensureBucketExist();
     console.log(`[s3] read ${targetPath}`);
 
-    const remotePath = targetPath.includes(REPORTS_BUCKET) ? targetPath : `${REPORTS_BUCKET}/${targetPath}`;
+    const remotePath = getRemotePath(targetPath);
 
     console.log(`[s3] reading from remote path: ${remotePath}`);
 
@@ -241,6 +244,20 @@ export class S3 implements Storage {
     }
 
     return result!;
+  }
+
+  async readFileStream(targetPath: string, range?: FileRange): Promise<FileStreamResult> {
+    await this.ensureBucketExist();
+    const remotePath = getRemotePath(targetPath);
+
+    const stat = await this.client.statObject(this.bucket, remotePath);
+    const totalSize = stat.size;
+
+    const { start, end, contentLength } = resolveFileRange(totalSize, range);
+
+    const stream = await this.client.getPartialObject(this.bucket, remotePath, start, contentLength);
+
+    return { stream, totalSize, start, end, contentLength };
   }
 
   async readResults(input?: ReadResultsInput): Promise<ReadResultsOutput> {

--- a/app/lib/storage/types.test.ts
+++ b/app/lib/storage/types.test.ts
@@ -1,0 +1,87 @@
+import { parseRangeHeader, resolveFileRange } from './types';
+
+describe('parseRangeHeader', () => {
+  it('parses a closed range "bytes=0-1023"', () => {
+    expect(parseRangeHeader('bytes=0-1023')).toEqual({ start: 0, end: 1023 });
+  });
+
+  it('parses an open-ended range "bytes=512-"', () => {
+    expect(parseRangeHeader('bytes=512-')).toEqual({ start: 512, end: undefined });
+  });
+
+  it('parses a suffix range "bytes=-256"', () => {
+    expect(parseRangeHeader('bytes=-256')).toEqual({ suffixLength: 256 });
+  });
+
+  it('returns null for an empty range "bytes=-"', () => {
+    expect(parseRangeHeader('bytes=-')).toBeNull();
+  });
+
+  it('returns null for "bytes="', () => {
+    expect(parseRangeHeader('bytes=')).toBeNull();
+  });
+
+  it('returns null for a non-bytes unit', () => {
+    expect(parseRangeHeader('items=0-1')).toBeNull();
+  });
+
+  it('returns null for non-numeric bounds', () => {
+    expect(parseRangeHeader('bytes=abc-def')).toBeNull();
+  });
+});
+
+describe('resolveFileRange', () => {
+  const totalSize = 5000;
+
+  it('serves the whole file when no range is given', () => {
+    expect(resolveFileRange(totalSize)).toEqual({ start: 0, end: 4999, contentLength: 5000 });
+  });
+
+  it('resolves a closed range', () => {
+    expect(resolveFileRange(totalSize, { start: 0, end: 1023 })).toEqual({
+      start: 0,
+      end: 1023,
+      contentLength: 1024,
+    });
+  });
+
+  it('resolves an open-ended range to the last byte', () => {
+    expect(resolveFileRange(totalSize, { start: 500 })).toEqual({
+      start: 500,
+      end: 4999,
+      contentLength: 4500,
+    });
+  });
+
+  it('clamps an end past EOF to the last byte', () => {
+    expect(resolveFileRange(totalSize, { start: 0, end: 999999 })).toEqual({
+      start: 0,
+      end: 4999,
+      contentLength: 5000,
+    });
+  });
+
+  it('resolves a suffix range against the file size', () => {
+    expect(resolveFileRange(totalSize, { suffixLength: 256 })).toEqual({
+      start: 4744,
+      end: 4999,
+      contentLength: 256,
+    });
+  });
+
+  it('clamps a suffix larger than the file to the whole file', () => {
+    expect(resolveFileRange(totalSize, { suffixLength: 999999 })).toEqual({
+      start: 0,
+      end: 4999,
+      contentLength: 5000,
+    });
+  });
+
+  it('yields a non-positive contentLength when start is past EOF (416 boundary)', () => {
+    expect(resolveFileRange(totalSize, { start: 5000 })).toEqual({
+      start: 5000,
+      end: 4999,
+      contentLength: 0,
+    });
+  });
+});

--- a/app/lib/storage/types.ts
+++ b/app/lib/storage/types.ts
@@ -1,4 +1,4 @@
-import { PassThrough } from 'node:stream';
+import { PassThrough, Readable } from 'node:stream';
 
 import { type Pagination } from './pagination';
 
@@ -10,9 +10,52 @@ export interface ReportFile {
   storagePath: string;
 }
 
+export interface FileRange {
+  /** First byte offset to serve (defaults to 0) */
+  start?: number;
+  /** Inclusive end byte offset (defaults to the last byte) */
+  end?: number;
+  /** Serve the last N bytes; resolved against the file size by the backend */
+  suffixLength?: number;
+}
+
+/** Resolve a (possibly partial or suffix) range request against a known file size. */
+export function resolveFileRange(
+  totalSize: number,
+  range?: FileRange,
+): { start: number; end: number; contentLength: number } {
+  let start = range?.start ?? 0;
+  let end = range?.end ?? totalSize - 1;
+
+  if (range?.suffixLength !== undefined) {
+    start = totalSize - range.suffixLength;
+    end = totalSize - 1;
+  }
+
+  start = Math.max(0, start);
+  end = Math.min(end, totalSize - 1);
+
+  return { start, end, contentLength: end - start + 1 };
+}
+
+export interface FileStreamResult {
+  /** Node.js Readable stream for the requested byte range */
+  stream: Readable;
+  /** Total size of the file in bytes */
+  totalSize: number;
+  /** Actual start byte served (may differ when clamped) */
+  start: number;
+  /** Actual end byte served, inclusive */
+  end: number;
+  /** Number of bytes in the stream (end - start + 1) */
+  contentLength: number;
+}
+
 export interface Storage {
   getServerDataInfo: () => Promise<ServerDataInfo>;
   readFile: (targetPath: string, contentType: string | null) => Promise<string | Buffer>;
+  /** Stream a byte range of a report asset. When `range` is omitted, stream the whole file. */
+  readFileStream: (targetPath: string, range?: FileRange) => Promise<FileStreamResult>;
   readResults: (input?: ReadResultsInput) => Promise<ReadResultsOutput>;
   readReports: (input?: ReadReportsInput) => Promise<ReadReportsOutput>;
   deleteResults: (resultIDs: string[]) => Promise<void>;

--- a/app/lib/storage/types.ts
+++ b/app/lib/storage/types.ts
@@ -19,6 +19,30 @@ export interface FileRange {
   suffixLength?: number;
 }
 
+/**
+ * Parse an HTTP Range header (e.g. "bytes=0-1023", "bytes=512-", "bytes=-256")
+ * into a {@link FileRange}. The backend resolves open-ended and suffix ranges
+ * against the file size. Returns null for a malformed / non-bytes range.
+ */
+export function parseRangeHeader(rangeHeader: string): FileRange | null {
+  const match = rangeHeader.match(/^bytes=(\d*)-(\d*)$/);
+
+  if (!match) return null;
+
+  const [, rawStart, rawEnd] = match;
+
+  if (rawStart === '' && rawEnd === '') return null;
+
+  if (rawStart === '') {
+    return { suffixLength: parseInt(rawEnd, 10) };
+  }
+
+  return {
+    start: parseInt(rawStart, 10),
+    end: rawEnd === '' ? undefined : parseInt(rawEnd, 10),
+  };
+}
+
 /** Resolve a (possibly partial or suffix) range request against a known file size. */
 export function resolveFileRange(
   totalSize: number,
@@ -54,7 +78,11 @@ export interface FileStreamResult {
 export interface Storage {
   getServerDataInfo: () => Promise<ServerDataInfo>;
   readFile: (targetPath: string, contentType: string | null) => Promise<string | Buffer>;
-  /** Stream a byte range of a report asset. When `range` is omitted, stream the whole file. */
+  /**
+   * Stream a byte range of a report asset. When `range` is omitted, stream the whole file.
+   * For an unsatisfiable range (e.g. `start` past EOF) the returned `stream` is empty and
+   * `contentLength` is `<= 0`, so the caller can respond 416 instead of crashing.
+   */
   readFileStream: (targetPath: string, range?: FileRange) => Promise<FileStreamResult>;
   readResults: (input?: ReadResultsInput) => Promise<ReadResultsOutput>;
   readReports: (input?: ReadReportsInput) => Promise<ReadReportsOutput>;

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -9,7 +9,7 @@ const createJestConfig = nextJest({
 
 // Add any custom config to be passed to Jest
 const config: Config = {
-  testMatch: ['app/**/*.test.ts'],
+  testMatch: ['<rootDir>/app/**/*.test.ts'],
   coverageProvider: 'v8',
   //testEnvironment: 'jsdom',
   // Add more setup options before each test is run

--- a/tests/api/serve.test.ts
+++ b/tests/api/serve.test.ts
@@ -1,0 +1,51 @@
+import { expect } from '@playwright/test';
+import { test } from './fixtures/base';
+
+// Exercises the Range/streaming behaviour of /api/serve/[[...filePath]] against a
+// real generated report. The `generatedReport` fixture uploads correct_blob.zip and
+// generates a Smoke report whose `reportUrl` points at the served index.html.
+test.describe.serial('GET /api/serve range support', () => {
+  test('serves full file, partial ranges, suffix ranges and falls back on a bad range', async ({
+    request,
+    generatedReport,
+  }) => {
+    const serveUrl = generatedReport.body.reportUrl;
+    expect(serveUrl).toContain('/api/serve/');
+
+    // Full file — advertises range support; capture the total size from the body.
+    const full = await request.get(serveUrl);
+    expect(full.status()).toBe(200);
+    expect(full.headers()['accept-ranges']).toBe('bytes');
+    const size = (await full.body()).length;
+    expect(size).toBeGreaterThan(11);
+
+    // Closed range "bytes=0-10" → 206 with the first 11 bytes.
+    const closed = await request.get(serveUrl, { headers: { Range: 'bytes=0-10' } });
+    expect(closed.status()).toBe(206);
+    expect(closed.headers()['content-range']).toBe(`bytes 0-10/${size}`);
+    expect(closed.headers()['content-length']).toBe('11');
+    expect((await closed.body()).length).toBe(11);
+
+    // Suffix range "bytes=-5" → last 5 bytes.
+    const suffix = await request.get(serveUrl, { headers: { Range: 'bytes=-5' } });
+    expect(suffix.status()).toBe(206);
+    expect(suffix.headers()['content-range']).toBe(`bytes ${size - 5}-${size - 1}/${size}`);
+    expect((await suffix.body()).length).toBe(5);
+
+    // Open-ended range "bytes=X-" → from X to the last byte.
+    const open = await request.get(serveUrl, { headers: { Range: `bytes=${size - 3}-` } });
+    expect(open.status()).toBe(206);
+    expect(open.headers()['content-range']).toBe(`bytes ${size - 3}-${size - 1}/${size}`);
+    expect((await open.body()).length).toBe(3);
+
+    // A start past EOF → 416 Range Not Satisfiable with an unbounded Content-Range.
+    const oob = await request.get(serveUrl, { headers: { Range: `bytes=${size}-${size + 10}` } });
+    expect(oob.status()).toBe(416);
+    expect(oob.headers()['content-range']).toBe(`bytes */${size}`);
+
+    // Malformed range header → falls through to the buffered 200 response.
+    const malformed = await request.get(serveUrl, { headers: { Range: 'bytes=abc' } });
+    expect(malformed.status()).toBe(200);
+    expect(malformed.headers()['content-range']).toBeUndefined();
+  });
+});


### PR DESCRIPTION
E2e tests occasionally produce video recordings exceeding 100MB. Previously, the server read the entire file into memory before serving it to the browser.
This PR adds Content-Range HTTP header support for partial file streaming, allowing the browser's video player to stream video in chunks and begin playback immediately. It also enables seeking, with the server streaming only from the requested byte offset onward.