### PR TITLE
feat: add "level of testing" as a first-class dimension

### DIFF
--- a/app/api/report/levels/route.ts
+++ b/app/api/report/levels/route.ts
@@ -1,0 +1,14 @@
+import { service } from '@/app/lib/service';
+import { withError } from '@/app/lib/withError';
+
+export const dynamic = 'force-dynamic'; // defaults to auto
+
+export async function GET() {
+  const { result: levels, error } = await withError(service.getReportsLevels());
+
+  if (error) {
+    return new Response(error.message, { status: 400 });
+  }
+
+  return Response.json(levels);
+}

--- a/app/api/report/list/route.ts
+++ b/app/api/report/list/route.ts
@@ -11,6 +11,7 @@ export async function GET(request: NextRequest) {
   const { searchParams } = new URL(request.url);
   const pagination = parseFromRequest(searchParams);
   const project = searchParams.get('project') ?? '';
+  const level = searchParams.get('level') ?? '';
   const search = searchParams.get('search') ?? '';
   const dateFrom = searchParams.get('dateFrom') ?? undefined;
   const dateTo = searchParams.get('dateTo') ?? undefined;
@@ -19,7 +20,7 @@ export async function GET(request: NextRequest) {
   const sortBy = parseReportSortField(searchParams.get('sortBy'));
 
   const { result: reports, error } = await withError(
-    service.getReports({ pagination, project, search, dateFrom, dateTo, order, sortBy }),
+    service.getReports({ pagination, project, level, search, dateFrom, dateTo, order, sortBy }),
   );
 
   if (error) {

--- a/app/api/result/levels/route.ts
+++ b/app/api/result/levels/route.ts
@@ -1,0 +1,14 @@
+import { service } from '@/app/lib/service';
+import { withError } from '@/app/lib/withError';
+
+export const dynamic = 'force-dynamic'; // defaults to auto
+
+export async function GET() {
+  const { result: levels, error } = await withError(service.getResultsLevels());
+
+  if (error) {
+    return new Response(error.message, { status: 400 });
+  }
+
+  return Response.json(levels);
+}

--- a/app/api/result/list/route.ts
+++ b/app/api/result/list/route.ts
@@ -11,6 +11,7 @@ export async function GET(request: NextRequest) {
   const { searchParams } = new URL(request.url);
   const pagination = parseFromRequest(searchParams);
   const project = searchParams.get('project') ?? '';
+  const level = searchParams.get('level') ?? '';
   const tags = searchParams.get('tags')?.split(',').filter(Boolean) ?? [];
   const search = searchParams.get('search') ?? '';
   const dateFrom = searchParams.get('dateFrom') ?? undefined;
@@ -20,7 +21,7 @@ export async function GET(request: NextRequest) {
   const sortBy = parseResultSortField(searchParams.get('sortBy'));
 
   const { result, error } = await withError(
-    service.getResults({ pagination, project, tags, search, dateFrom, dateTo, order, sortBy }),
+    service.getResults({ pagination, project, level, tags, search, dateFrom, dateTo, order, sortBy }),
   );
 
   if (error) {

--- a/app/components/level-select.tsx
+++ b/app/components/level-select.tsx
@@ -1,0 +1,58 @@
+'use client';
+
+import { Select, SelectItem, SharedSelection } from '@heroui/react';
+import { toast } from 'sonner';
+
+import useQuery from '../hooks/useQuery';
+import { defaultLevelName } from '../lib/constants';
+
+interface LevelSelectProps {
+  onSelect: (level: string) => void;
+  refreshId?: string;
+  entity: 'result' | 'report';
+}
+
+export default function LevelSelect({ refreshId, onSelect, entity }: Readonly<LevelSelectProps>) {
+  const {
+    data: levels,
+    error,
+    isLoading,
+  } = useQuery<string[]>(`/api/${entity}/levels`, {
+    dependencies: [refreshId],
+  });
+
+  const items = [defaultLevelName, ...(levels ?? [])];
+
+  const onChange = (keys: SharedSelection) => {
+    if (keys === defaultLevelName.toString()) {
+      onSelect?.(defaultLevelName);
+
+      return;
+    }
+
+    if (!keys.currentKey) {
+      return;
+    }
+
+    onSelect?.(keys.currentKey);
+  };
+
+  error && toast.error(error.message);
+
+  return (
+    <Select
+      className="w-36 min-w-36 bg-transparent"
+      defaultSelectedKeys={[defaultLevelName]}
+      isDisabled={items.length <= 1}
+      isLoading={isLoading}
+      label="Level"
+      labelPlacement="outside"
+      variant="bordered"
+      onSelectionChange={onChange}
+    >
+      {items.map((level) => (
+        <SelectItem key={level}>{level}</SelectItem>
+      ))}
+    </Select>
+  );
+}

--- a/app/components/reports-table.tsx
+++ b/app/components/reports-table.tsx
@@ -26,7 +26,7 @@ import TablePaginationOptions from './table-pagination-options';
 import InlineStatsCircle from './inline-stats-circle';
 
 import { withQueryParams } from '@/app/lib/network';
-import { defaultProjectName } from '@/app/lib/constants';
+import { defaultLevelName, defaultProjectName } from '@/app/lib/constants';
 import useQuery from '@/app/hooks/useQuery';
 import DeleteReportButton from '@/app/components/delete-report-button';
 import FormattedDate from '@/app/components/date-format';
@@ -36,6 +36,7 @@ import { ReadReportsHistory, ReportHistory } from '@/app/lib/storage';
 const columns = [
   { name: 'Title', uid: 'title', sortable: true },
   { name: 'Project', uid: 'project', sortable: true },
+  { name: 'Level', uid: 'level', sortable: true },
   { name: 'Pass Rate', uid: 'passRate', sortable: true },
   { name: 'Created at', uid: 'createdAt', sortable: true },
   { name: 'Size', uid: 'size', sortable: true },
@@ -46,6 +47,7 @@ const coreFields = [
   'reportID',
   'title',
   'project',
+  'level',
   'createdAt',
   'size',
   'sizeBytes',
@@ -121,6 +123,7 @@ interface ReportsTableProps {
 export default function ReportsTable({ onChange, selected, onSelect, onDeleted }: Readonly<ReportsTableProps>) {
   const reportListEndpoint = '/api/report/list';
   const [project, setProject] = useState(defaultProjectName);
+  const [level, setLevel] = useState(defaultLevelName);
   const [search, setSearch] = useState('');
   const [dateFrom, setDateFrom] = useState<string>('');
   const [dateTo, setDateTo] = useState<string>('');
@@ -135,6 +138,7 @@ export default function ReportsTable({ onChange, selected, onSelect, onDeleted }
     limit: rowsPerPage.toString(),
     offset: ((page - 1) * rowsPerPage).toString(),
     project,
+    level,
     order: sortDescriptor.direction === 'ascending' ? 'asc' : 'desc',
     sortBy: String(sortDescriptor.column ?? 'createdAt'),
     ...(search.trim() && { search: search.trim() }),
@@ -151,6 +155,7 @@ export default function ReportsTable({ onChange, selected, onSelect, onDeleted }
   } = useQuery<ReadReportsHistory>(withQueryParams(reportListEndpoint, getQueryParams()), {
     dependencies: [
       project,
+      level,
       search,
       dateFrom,
       dateTo,
@@ -202,6 +207,11 @@ export default function ReportsTable({ onChange, selected, onSelect, onDeleted }
     [page, rowsPerPage],
   );
 
+  const onLevelChange = useCallback((level: string) => {
+    setLevel(level);
+    setPage(1);
+  }, []);
+
   const onSearchChange = useCallback((searchTerm: string) => {
     setSearch(searchTerm);
     setPage(1);
@@ -242,6 +252,7 @@ export default function ReportsTable({ onChange, selected, onSelect, onDeleted }
         total={total}
         onDateFromChange={onDateFromChange}
         onDateToChange={onDateToChange}
+        onLevelChange={onLevelChange}
         onProjectChange={onProjectChange}
         onSearchChange={onSearchChange}
       />
@@ -326,6 +337,7 @@ export default function ReportsTable({ onChange, selected, onSelect, onDeleted }
                 </div>
               </TableCell>
               <TableCell className="w-1/6">{item.project}</TableCell>
+              <TableCell className="w-1/12">{item.level}</TableCell>
               <TableCell className="w-1/12">{<InlineStatsCircle stats={item.stats} />}</TableCell>
               <TableCell className="w-1/6">
                 <FormattedDate date={item.createdAt} />

--- a/app/components/results-table.tsx
+++ b/app/components/results-table.tsx
@@ -18,7 +18,7 @@ import { keepPreviousData } from '@tanstack/react-query';
 import { toast } from 'sonner';
 
 import { withQueryParams } from '@/app/lib/network';
-import { defaultProjectName } from '@/app/lib/constants';
+import { defaultLevelName, defaultProjectName } from '@/app/lib/constants';
 import TablePaginationOptions from '@/app/components/table-pagination-options';
 import useQuery from '@/app/hooks/useQuery';
 import FormattedDate from '@/app/components/date-format';
@@ -28,13 +28,14 @@ import DeleteResultsButton from '@/app/components/delete-results-button';
 const columns = [
   { name: 'Result ID', uid: 'title', sortable: true },
   { name: 'Project', uid: 'project', sortable: true },
+  { name: 'Level', uid: 'level', sortable: true },
   { name: 'Created at', uid: 'createdAt', sortable: true },
   { name: 'Tags', uid: 'tags', sortable: true },
   { name: 'Size', uid: 'size', sortable: true },
   { name: '', uid: 'actions' },
 ];
 
-const notMetadataKeys = ['resultID', 'title', 'createdAt', 'size', 'sizeBytes', 'project'];
+const notMetadataKeys = ['resultID', 'title', 'createdAt', 'size', 'sizeBytes', 'project', 'level'];
 
 const getTags = (item: Result) => {
   return Object.entries(item).filter(([key]) => !notMetadataKeys.includes(key));
@@ -49,6 +50,7 @@ interface ResultsTableProps {
 export default function ResultsTable({ onSelect, onDeleted, selected }: Readonly<ResultsTableProps>) {
   const resultListEndpoint = '/api/result/list';
   const [project, setProject] = useState(defaultProjectName);
+  const [level, setLevel] = useState(defaultLevelName);
   const [selectedTags, setSelectedTags] = useState<string[]>([]);
   const [search, setSearch] = useState('');
   const [dateFrom, setDateFrom] = useState<string>('');
@@ -64,6 +66,7 @@ export default function ResultsTable({ onSelect, onDeleted, selected }: Readonly
     limit: rowsPerPage.toString(),
     offset: ((page - 1) * rowsPerPage).toString(),
     project,
+    level,
     order: sortDescriptor.direction === 'ascending' ? 'asc' : 'desc',
     sortBy: String(sortDescriptor.column ?? 'createdAt'),
     ...(selectedTags.length > 0 && { tags: selectedTags.join(',') }),
@@ -81,6 +84,7 @@ export default function ResultsTable({ onSelect, onDeleted, selected }: Readonly
   } = useQuery<ReadResultsOutput>(withQueryParams(resultListEndpoint, getQueryParams()), {
     dependencies: [
       project,
+      level,
       selectedTags,
       search,
       dateFrom,
@@ -114,6 +118,11 @@ export default function ResultsTable({ onSelect, onDeleted, selected }: Readonly
     },
     [page, rowsPerPage],
   );
+
+  const onLevelChange = useCallback((level: string) => {
+    setLevel(level);
+    setPage(1);
+  }, []);
 
   const onTagsChange = useCallback((tags: string[]) => {
     setSelectedTags(tags);
@@ -176,6 +185,7 @@ export default function ResultsTable({ onSelect, onDeleted, selected }: Readonly
         total={total}
         onDateFromChange={onDateFromChange}
         onDateToChange={onDateToChange}
+        onLevelChange={onLevelChange}
         onProjectChange={onProjectChange}
         onSearchChange={onSearchChange}
         onTagsChange={onTagsChange}
@@ -240,6 +250,7 @@ export default function ResultsTable({ onSelect, onDeleted, selected }: Readonly
             <TableRow key={item.resultID}>
               <TableCell className="w-1/3">{item.title ?? item.resultID}</TableCell>
               <TableCell className="w-1/6">{item.project}</TableCell>
+              <TableCell className="w-1/12">{item.level}</TableCell>
               <TableCell className="w-1/12">
                 <FormattedDate date={new Date(item.createdAt)} />
               </TableCell>

--- a/app/components/table-pagination-options.tsx
+++ b/app/components/table-pagination-options.tsx
@@ -2,6 +2,7 @@ import { type ChangeEvent, useCallback } from 'react';
 import { Select, SelectItem, Input } from '@heroui/react';
 
 import ProjectSelect from '@/app/components/project-select';
+import LevelSelect from '@/app/components/level-select';
 import TagSelect from '@/app/components/tag-select';
 import DateRangePicker from '@/app/components/date-range-picker';
 import { SearchIcon } from '@/app/components/icons';
@@ -12,6 +13,7 @@ interface TablePaginationRowProps {
   setRowsPerPage: (rows: number) => void;
   setPage: (page: number) => void;
   onProjectChange: (project: string) => void;
+  onLevelChange?: (level: string) => void;
   onSearchChange?: (search: string) => void;
   onTagsChange?: (tags: string[]) => void;
   onDateFromChange?: (date: string) => void;
@@ -32,6 +34,7 @@ export default function TablePaginationOptions({
   setRowsPerPage,
   setPage,
   onProjectChange,
+  onLevelChange,
   onSearchChange,
   onTagsChange,
   onDateFromChange,
@@ -63,6 +66,7 @@ export default function TablePaginationOptions({
           onChange={(e) => onSearchChange?.(e.target.value)}
         />
         <ProjectSelect entity={entity} onSelect={onProjectChange} />
+        {onLevelChange && <LevelSelect entity={entity} onSelect={onLevelChange} />}
         {entity === 'result' && <TagSelect entity={entity} onSelect={onTagsChange} />}
         {(onDateFromChange || onDateToChange) && (
           <DateRangePicker

--- a/app/lib/constants.ts
+++ b/app/lib/constants.ts
@@ -1,3 +1,5 @@
 export const serveReportRoute = '/api/serve';
 
 export const defaultProjectName = 'all';
+
+export const defaultLevelName = 'all';

--- a/app/lib/network.ts
+++ b/app/lib/network.ts
@@ -1,4 +1,4 @@
-import { defaultProjectName } from './constants';
+import { defaultLevelName, defaultProjectName } from './constants';
 
 export class CommonResponseFactory {
   static buildUnauthorizedResponse(): Response {
@@ -9,6 +9,10 @@ export class CommonResponseFactory {
 export const withQueryParams = (url: string, params: Record<string, string>): string => {
   if (params?.project === defaultProjectName) {
     delete params.project;
+  }
+
+  if (params?.level === defaultLevelName) {
+    delete params.level;
   }
 
   const searchParams = new URLSearchParams(params);

--- a/app/lib/service/index.ts
+++ b/app/lib/service/index.ts
@@ -1,7 +1,7 @@
 import { PassThrough, Readable } from 'node:stream';
 
 import { withError } from '../withError';
-import { bytesToString, getUniqueProjectsList } from '../storage/format';
+import { bytesToString, getUniqueLevelsList, getUniqueProjectsList } from '../storage/format';
 import { serveReportRoute } from '../constants';
 import { DEFAULT_STREAM_CHUNK_SIZE } from '../storage/constants';
 
@@ -50,11 +50,18 @@ class Service {
 
     if (cached.length && shouldUseCache) {
       console.log(`[service] using cached reports`);
+      // NB: `level` is intentionally excluded here — a level-only query must let all reports through
+      // this initial pass so the dedicated level filter below can narrow them (project/ids gate broad inclusion).
       const noFilters = !input?.project && !input?.ids;
       const shouldFilterByProject = (report: ReportHistory) => input?.project && report.project === input.project;
       const shouldFilterByID = (report: ReportHistory) => input?.ids?.includes(report.reportID);
 
       let reports = cached.filter((report) => noFilters || shouldFilterByProject(report) || shouldFilterByID(report));
+
+      // Filter by level (testing level) if provided
+      if (input?.level) {
+        reports = reports.filter((report) => report.level === input.level);
+      }
 
       // Filter by search if provided
       if (input?.search?.trim()) {
@@ -69,9 +76,17 @@ class Service {
             ...Object.entries(report)
               .filter(
                 ([key]) =>
-                  !['reportID', 'title', 'createdAt', 'size', 'sizeBytes', 'project', 'reportUrl', 'stats'].includes(
-                    key,
-                  ),
+                  ![
+                    'reportID',
+                    'title',
+                    'createdAt',
+                    'size',
+                    'sizeBytes',
+                    'project',
+                    'level',
+                    'reportUrl',
+                    'stats',
+                  ].includes(key),
               )
               .map(([key, value]) => `${key}: ${value}`),
           ].filter(Boolean);
@@ -223,6 +238,12 @@ class Service {
     return projects;
   }
 
+  public async getReportsLevels(): Promise<string[]> {
+    const { reports } = await this.getReports();
+
+    return getUniqueLevelsList(reports);
+  }
+
   public async getResults(input?: ReadResultsInput): Promise<ReadResultsOutput> {
     console.log(`[results service] getResults`);
     const cached = this.shouldUseServerCache() && resultCache.initialized ? resultCache.getAll() : [];
@@ -242,6 +263,10 @@ class Service {
       ? cached.filter((file) => (input?.project ? file.project === input.project : file))
       : cached;
 
+    if (input?.level) {
+      filtered = filtered.filter((file) => file.level === input.level);
+    }
+
     if (input?.testRun) {
       filtered = filtered.filter((file) => file.testRun === input.testRun);
     }
@@ -260,7 +285,7 @@ class Service {
 
     // Filter by tags if provided
     if (input?.tags && input.tags.length > 0) {
-      const notMetadataKeys = ['resultID', 'title', 'createdAt', 'size', 'sizeBytes', 'project'];
+      const notMetadataKeys = ['resultID', 'title', 'createdAt', 'size', 'sizeBytes', 'project', 'level'];
 
       filtered = filtered.filter((result) => {
         const resultTags = Object.entries(result)
@@ -282,7 +307,9 @@ class Service {
           result.resultID,
           result.project,
           ...Object.entries(result)
-            .filter(([key]) => !['resultID', 'title', 'createdAt', 'size', 'sizeBytes', 'project'].includes(key))
+            .filter(
+              ([key]) => !['resultID', 'title', 'createdAt', 'size', 'sizeBytes', 'project', 'level'].includes(key),
+            )
             .map(([key, value]) => `${key}: ${value}`),
         ].filter(Boolean);
 
@@ -383,10 +410,19 @@ class Service {
     return Array.from(new Set([...projects, ...reportProjects]));
   }
 
+  public async getResultsLevels(): Promise<string[]> {
+    const { results } = await this.getResults();
+    const resultLevels = getUniqueLevelsList(results);
+
+    const reportLevels = await this.getReportsLevels();
+
+    return Array.from(new Set([...resultLevels, ...reportLevels]));
+  }
+
   public async getResultsTags(project?: string): Promise<string[]> {
     const { results } = await this.getResults(project ? { project } : undefined);
 
-    const notMetadataKeys = ['resultID', 'title', 'createdAt', 'size', 'sizeBytes', 'project'];
+    const notMetadataKeys = ['resultID', 'title', 'createdAt', 'size', 'sizeBytes', 'project', 'level'];
     const allTags = new Set<string>();
 
     results.forEach((result) => {

--- a/app/lib/storage/azure.ts
+++ b/app/lib/storage/azure.ts
@@ -259,7 +259,7 @@ export class AzureBlob implements Storage {
 
     jsonFiles.sort((a, b) => resultsDir * (getTimestamp(a.lastModified) - getTimestamp(b.lastModified)));
 
-    const noFilters = !input?.project && !input?.pagination;
+    const noFilters = !input?.project && !input?.level && !input?.pagination;
     const resultFiles = noFilters ? handlePagination(jsonFiles, input?.pagination) : jsonFiles;
 
     const results = await processBatch<{ name: string }, Result>(this, resultFiles, this.batchSize, async (file) => {
@@ -276,9 +276,13 @@ export class AzureBlob implements Storage {
       return JSON.parse(Buffer.concat(chunks).toString());
     });
 
-    const notMetadataKeys = ['resultID', 'title', 'createdAt', 'size', 'sizeBytes', 'project'];
+    const notMetadataKeys = ['resultID', 'title', 'createdAt', 'size', 'sizeBytes', 'project', 'level'];
 
     let filteredResults = results.filter((file) => (input?.project ? file.project === input.project : file));
+
+    if (input?.level) {
+      filteredResults = filteredResults.filter((result) => result.level === input.level);
+    }
 
     if (input?.tags && input.tags.length > 0) {
       filteredResults = filteredResults.filter((result) => {
@@ -392,6 +396,10 @@ export class AzureBlob implements Storage {
 
     let filteredReports = withMetadata;
 
+    if (input?.level) {
+      filteredReports = filteredReports.filter((report) => report.level === input.level);
+    }
+
     if (input?.search && input.search.trim()) {
       const searchTerm = input.search.toLowerCase().trim();
 
@@ -403,7 +411,17 @@ export class AzureBlob implements Storage {
           ...Object.entries(report)
             .filter(
               ([key]) =>
-                !['reportID', 'title', 'createdAt', 'size', 'sizeBytes', 'project', 'reportUrl', 'stats'].includes(key),
+                ![
+                  'reportID',
+                  'title',
+                  'createdAt',
+                  'size',
+                  'sizeBytes',
+                  'project',
+                  'level',
+                  'reportUrl',
+                  'stats',
+                ].includes(key),
             )
             .map(([key, value]) => `${key}: ${value}`),
         ].filter(Boolean);
@@ -568,6 +586,7 @@ export class AzureBlob implements Storage {
       resultID,
       createdAt: new Date().toISOString(),
       project: resultDetails?.project ?? '',
+      level: resultDetails?.level ?? '',
       ...resultDetails,
       size: bytesToString(size),
       sizeBytes: size,

--- a/app/lib/storage/format.ts
+++ b/app/lib/storage/format.ts
@@ -16,3 +16,7 @@ export const bytesToString = (bytes: number): string => {
 export const getUniqueProjectsList = (items: (Result | Report)[]): string[] => {
   return Array.from(new Set(items.map((r) => r.project).filter(Boolean)));
 };
+
+export const getUniqueLevelsList = (items: (Result | Report)[]): string[] => {
+  return Array.from(new Set(items.map((r) => r.level).filter(Boolean))) as string[];
+};

--- a/app/lib/storage/fs.ts
+++ b/app/lib/storage/fs.ts
@@ -125,9 +125,14 @@ export async function readResults(input?: ReadResultsInput) {
 
   let filteredResults = fileContents.filter((result) => (input?.project ? result.project === input.project : result));
 
+  // Filter by level (testing level) if provided
+  if (input?.level) {
+    filteredResults = filteredResults.filter((result) => result.level === input.level);
+  }
+
   // Filter by tags if provided
   if (input?.tags && input.tags.length > 0) {
-    const notMetadataKeys = ['resultID', 'title', 'createdAt', 'size', 'sizeBytes', 'project'];
+    const notMetadataKeys = ['resultID', 'title', 'createdAt', 'size', 'sizeBytes', 'project', 'level'];
 
     filteredResults = filteredResults.filter((result) => {
       const resultTags = Object.entries(result)
@@ -149,7 +154,7 @@ export async function readResults(input?: ReadResultsInput) {
         result.resultID,
         result.project,
         ...Object.entries(result)
-          .filter(([key]) => !['resultID', 'title', 'createdAt', 'size', 'sizeBytes', 'project'].includes(key))
+          .filter(([key]) => !['resultID', 'title', 'createdAt', 'size', 'sizeBytes', 'project', 'level'].includes(key))
           .map(([key, value]) => `${key}: ${value}`),
       ].filter(Boolean);
 
@@ -290,6 +295,11 @@ export async function readReports(input?: ReadReportsInput): Promise<ReadReports
 
   let filteredReports = allReports as ReportHistory[];
 
+  // Filter by level (testing level) if provided
+  if (input?.level) {
+    filteredReports = filteredReports.filter((report) => report.level === input.level);
+  }
+
   // Filter by search if provided
   if (input?.search && input.search.trim()) {
     const searchTerm = input.search.toLowerCase().trim();
@@ -303,7 +313,17 @@ export async function readReports(input?: ReadReportsInput): Promise<ReadReports
         ...Object.entries(report)
           .filter(
             ([key]) =>
-              !['reportID', 'title', 'createdAt', 'size', 'sizeBytes', 'project', 'reportUrl', 'stats'].includes(key),
+              ![
+                'reportID',
+                'title',
+                'createdAt',
+                'size',
+                'sizeBytes',
+                'project',
+                'level',
+                'reportUrl',
+                'stats',
+              ].includes(key),
           )
           .map(([key, value]) => `${key}: ${value}`),
       ].filter(Boolean);
@@ -391,6 +411,7 @@ export async function saveResultDetails(resultID: string, resultDetails: ResultD
     resultID,
     createdAt: new Date().toISOString(),
     project: resultDetails?.project ?? '',
+    level: resultDetails?.level ?? '',
     ...resultDetails,
     size: bytesToString(size),
     sizeBytes: size,

--- a/app/lib/storage/s3.ts
+++ b/app/lib/storage/s3.ts
@@ -303,7 +303,7 @@ export class S3 implements Storage {
     jsonFiles.sort((a, b) => resultsDir * (getTimestamp(a.lastModified) - getTimestamp(b.lastModified)));
 
     // check if we can apply pagination early
-    const noFilters = !input?.project && !input?.pagination;
+    const noFilters = !input?.project && !input?.level && !input?.pagination;
 
     const resultFiles = noFilters ? handlePagination(jsonFiles, input?.pagination) : jsonFiles;
 
@@ -324,9 +324,14 @@ export class S3 implements Storage {
 
     let filteredResults = results.filter((file) => (input?.project ? file.project === input.project : file));
 
+    // Filter by level (testing level) if provided
+    if (input?.level) {
+      filteredResults = filteredResults.filter((result) => result.level === input.level);
+    }
+
     // Filter by tags if provided
     if (input?.tags && input.tags.length > 0) {
-      const notMetadataKeys = ['resultID', 'title', 'createdAt', 'size', 'sizeBytes', 'project'];
+      const notMetadataKeys = ['resultID', 'title', 'createdAt', 'size', 'sizeBytes', 'project', 'level'];
 
       filteredResults = filteredResults.filter((result) => {
         const resultTags = Object.entries(result)
@@ -348,7 +353,9 @@ export class S3 implements Storage {
           result.resultID,
           result.project,
           ...Object.entries(result)
-            .filter(([key]) => !['resultID', 'title', 'createdAt', 'size', 'sizeBytes', 'project'].includes(key))
+            .filter(
+              ([key]) => !['resultID', 'title', 'createdAt', 'size', 'sizeBytes', 'project', 'level'].includes(key),
+            )
             .map(([key, value]) => `${key}: ${value}`),
         ].filter(Boolean);
 
@@ -466,6 +473,11 @@ export class S3 implements Storage {
 
         let filteredReports = withMetadata;
 
+        // Filter by level (testing level) if provided
+        if (input?.level) {
+          filteredReports = filteredReports.filter((report) => report.level === input.level);
+        }
+
         // Filter by search if provided
         if (input?.search && input.search.trim()) {
           const searchTerm = input.search.toLowerCase().trim();
@@ -479,9 +491,17 @@ export class S3 implements Storage {
               ...Object.entries(report)
                 .filter(
                   ([key]) =>
-                    !['reportID', 'title', 'createdAt', 'size', 'sizeBytes', 'project', 'reportUrl', 'stats'].includes(
-                      key,
-                    ),
+                    ![
+                      'reportID',
+                      'title',
+                      'createdAt',
+                      'size',
+                      'sizeBytes',
+                      'project',
+                      'level',
+                      'reportUrl',
+                      'stats',
+                    ].includes(key),
                 )
                 .map(([key, value]) => `${key}: ${value}`),
             ].filter(Boolean);
@@ -660,6 +680,7 @@ export class S3 implements Storage {
       resultID,
       createdAt: new Date().toISOString(),
       project: resultDetails?.project ?? '',
+      level: resultDetails?.level ?? '',
       ...resultDetails,
       size: bytesToString(size),
       sizeBytes: size,

--- a/app/lib/storage/sort.ts
+++ b/app/lib/storage/sort.ts
@@ -1,11 +1,25 @@
 import { type Report, type Result, type ReportHistory, type SortOrder } from './types';
 
-export type ReportSortField = 'createdAt' | 'title' | 'project' | 'passRate' | 'size';
-export type ResultSortField = 'createdAt' | 'title' | 'project' | 'tags' | 'size';
+export type ReportSortField = 'createdAt' | 'title' | 'project' | 'level' | 'passRate' | 'size';
+export type ResultSortField = 'createdAt' | 'title' | 'project' | 'level' | 'tags' | 'size';
 
-export const REPORT_SORT_FIELDS: readonly ReportSortField[] = ['createdAt', 'title', 'project', 'passRate', 'size'];
+export const REPORT_SORT_FIELDS: readonly ReportSortField[] = [
+  'createdAt',
+  'title',
+  'project',
+  'level',
+  'passRate',
+  'size',
+];
 
-export const RESULT_SORT_FIELDS: readonly ResultSortField[] = ['createdAt', 'title', 'project', 'tags', 'size'];
+export const RESULT_SORT_FIELDS: readonly ResultSortField[] = [
+  'createdAt',
+  'title',
+  'project',
+  'level',
+  'tags',
+  'size',
+];
 
 export const parseReportSortField = (value: string | null | undefined): ReportSortField | undefined =>
   (REPORT_SORT_FIELDS as readonly string[]).includes(value ?? '') ? (value as ReportSortField) : undefined;
@@ -20,7 +34,7 @@ const toTimestamp = (date?: Date | string) => {
   return date.getTime();
 };
 
-const RESULT_METADATA_EXCLUDE = ['resultID', 'title', 'createdAt', 'size', 'sizeBytes', 'project'];
+const RESULT_METADATA_EXCLUDE = ['resultID', 'title', 'createdAt', 'size', 'sizeBytes', 'project', 'level'];
 
 const resultTagsString = (item: Result): string =>
   Object.entries(item)
@@ -49,6 +63,8 @@ export const getReportSortValue = (item: ReportHistory, field: ReportSortField):
       return (item.title ?? item.reportID ?? '').toLowerCase();
     case 'project':
       return (item.project ?? '').toLowerCase();
+    case 'level':
+      return (item.level ?? '').toLowerCase();
     case 'passRate':
       return reportPassRate(item);
     case 'size':
@@ -64,6 +80,8 @@ export const getResultSortValue = (item: Result, field: ResultSortField): number
       return (item.title ?? item.resultID ?? '').toLowerCase();
     case 'project':
       return (item.project ?? '').toLowerCase();
+    case 'level':
+      return (item.level ?? '').toLowerCase();
     case 'tags':
       return resultTagsString(item);
     case 'size':

--- a/app/lib/storage/types.ts
+++ b/app/lib/storage/types.ts
@@ -32,13 +32,14 @@ export type SortOrder = 'asc' | 'desc';
 export interface ReadResultsInput {
   pagination?: Pagination;
   project?: string;
+  level?: string;
   testRun?: string;
   tags?: string[];
   search?: string;
   dateFrom?: string;
   dateTo?: string;
   order?: SortOrder;
-  sortBy?: 'createdAt' | 'title' | 'project' | 'tags' | 'size';
+  sortBy?: 'createdAt' | 'title' | 'project' | 'level' | 'tags' | 'size';
 }
 
 export interface ReadResultsOutput {
@@ -49,12 +50,13 @@ export interface ReadResultsOutput {
 export interface ReadReportsInput {
   pagination?: Pagination;
   project?: string;
+  level?: string;
   ids?: string[];
   search?: string;
   dateFrom?: string;
   dateTo?: string;
   order?: SortOrder;
-  sortBy?: 'createdAt' | 'title' | 'project' | 'passRate' | 'size';
+  sortBy?: 'createdAt' | 'title' | 'project' | 'level' | 'passRate' | 'size';
 }
 
 export interface ReadReportsOutput {
@@ -77,6 +79,7 @@ export type Result = {
   title?: string;
   createdAt: string;
   project: string;
+  level?: string;
   size: string;
   sizeBytes: number;
 } & ResultDetails;
@@ -85,6 +88,7 @@ export type Report = {
   reportID: string;
   title?: string;
   project: string;
+  level?: string;
   reportUrl: string;
   createdAt: Date;
   size: string;
@@ -98,7 +102,7 @@ export const isReportHistory = (report: Report | ReportHistory | undefined): rep
 
 export type TestHistory = Report & ReportTest;
 
-export type ReportMetadata = Partial<{ title: string; project: string; playwrightVersion?: string }> &
+export type ReportMetadata = Partial<{ title: string; project: string; level: string; playwrightVersion?: string }> &
   Record<string, string>;
 
 export interface ServerDataInfo {

--- a/readme.md
+++ b/readme.md
@@ -246,9 +246,16 @@ curl --location --request PUT 'http://localhost:3000/api/result/upload' \
 --header 'Authorization: <api-token>' \
 --form 'file=@"/path/to/file"' \
 --form 'project="desktop"' \
+--form 'level="e2e"' \
 --form 'reporter="okhotemskyi"' \
 --form 'appVersion="1.2.2"'
 ```
+
+Alongside `project`, the `level` field is a first-class dimension describing the **testing level**
+(e.g. `unit`, `integration`, `e2e`). Like `project`, it is stored on the result, carried onto the
+generated report, is filterable via the `level` query param on `/api/report/list` and `/api/result/list`,
+enumerable via `/api/report/levels` and `/api/result/levels`, and shown as a dedicated column/filter in
+the UI (rather than as a generic tag).
 
 If you have **s3 storage** configured, you can pass `fileContentLength` query parameter to use **presigned URL** for **direct upload**:
 


### PR DESCRIPTION
## Summary

Adds a **`level`** field (e.g. `unit`, `integration`, `e2e`) as a first-class dimension **alongside `project`**, so reports and results can be grouped and filtered by the *kind* of testing — not just by project/suite. It mirrors how `project` works everywhere **except** that `level` is **metadata-only and never a filesystem-path segment**, which keeps the change fully backward-compatible.

## Motivation

`project` is currently the only categorical axis, so teams end up encoding the testing level into the project name (`myapp-unit`, `myapp-e2e`, …). That makes it impossible to ask "show me all `e2e` results across every project" or "everything for `myapp` regardless of level". Promoting `level` to its own dimension solves both.

## What's included

- **Types** — `level?` on `Result`, `Report`, `ReportMetadata`, `ReadResultsInput`/`ReadReportsInput`, and the sort unions.
- **Storage (fs / s3 / azure)** — filter by `level`; keep it out of the generic "tags" bucket so it gets its own column/filter; default it in `saveResultDetails`.
- **Service cache** — the cached read path filters by `level` too (a level-only query still works).
- **Enumeration** — `getUniqueLevelsList` + new `GET /api/report/levels` and `GET /api/result/levels` (mirroring the `projects` routes).
- **List routes** — `?level=` filter on `/api/report/list` and `/api/result/list`.
- **Sort** — `level` is a sortable field.
- **UI** — a `LevelSelect` dropdown in the filter toolbar (both reports & results) + a **Level** column on both tables.
- **Docs** — the `level` upload field is documented in the README.

## Backward compatibility

- `level` is **optional** everywhere. Existing reports/results without it are unaffected (blank Level column, absent from the levels list).
- **Ingestion (`/api/result/upload`) and generation (`/api/report/generate`) are unchanged** — they already accept/forward arbitrary custom fields, so a client that sends `level` populates it automatically; one that doesn't sees no change.
- Because `level` is **not** a path segment (unlike `project`), there's **no migration** and no change to report directory layout or `pw.ts`.

## Testing

- `tsc --noEmit` and `eslint` clean on all touched files.
- Verified end-to-end against the `fs` backend: uploaded blobs with `level=unit` / `level=integration`, generated reports, then confirmed `/api/{report,result}/levels` → `["integration","unit"]`, `?project=<p>&level=unit` returns only the matching report, and a cross-project `?level=integration` filter works. The Level dropdown/column render and filter in the UI.

This has been running in production in our deployment.