### PR TITLE
Streaming rebased

### DIFF
--- a/apps/backend/src/lib/storage/azure.ts
+++ b/apps/backend/src/lib/storage/azure.ts
@@ -1,7 +1,7 @@
 import { randomUUID, type UUID } from 'node:crypto';
 import fs from 'node:fs/promises';
 import path from 'node:path';
-import { PassThrough, type Readable } from 'node:stream';
+import { PassThrough, Readable } from 'node:stream';
 import {
   BlobServiceClient,
   type ContainerClient,
@@ -27,6 +27,7 @@ import type {
   ReportUploadMetadata,
   Storage,
 } from './types.js';
+import { resolveFileRange } from './types.js';
 
 const createClient = (): {
   serviceClient: BlobServiceClient;
@@ -89,10 +90,48 @@ export class AzureBlob implements Storage {
       ? targetPath
       : `${REPORTS_BUCKET}/${targetPath}`;
 
+    // Fetch blob properties to resolve suffix ranges against the actual file size.
     const blobClient = this.container.getBlobClient(remotePath);
-    const count = range?.end !== undefined ? range.end - range.start + 1 : undefined;
+
+    if (range?.suffixLength !== undefined) {
+      // Suffix range: resolve against actual blob size before issuing download.
+      const properties = await blobClient.getProperties();
+      const totalSize = properties.contentLength ?? 0;
+      const resolved = resolveFileRange(totalSize, range);
+
+      if (resolved.contentLength <= 0) {
+        // Unsatisfiable: start past EOF.
+        return {
+          body: Readable.from([]),
+          size: 0,
+          totalSize,
+          contentRange: { start: resolved.start, end: resolved.end, total: totalSize },
+        };
+      }
+
+      const { result: response, error } = await withError(
+        blobClient.download(resolved.start, resolved.contentLength)
+      );
+
+      if (error || !response?.readableStreamBody) {
+        if (error) console.error(`[azure] failed to read file ${targetPath}: ${error.message}`);
+        return null;
+      }
+
+      return {
+        body: response.readableStreamBody as unknown as Readable,
+        size: resolved.contentLength,
+        totalSize,
+        contentRange: { start: resolved.start, end: resolved.end, total: totalSize },
+      };
+    }
+
+    // Standard (non-suffix) range: pass range bounds directly to Azure.
+    // `start` is guaranteed to be defined here because prefix ranges from
+    // parseRangeHeader always include start, and suffixLength was handled above.
+    const count = range?.end !== undefined ? range.end - (range.start ?? 0) + 1 : undefined;
     const { result: response, error } = await withError(
-      range ? blobClient.download(range.start, count) : blobClient.download()
+      range ? blobClient.download(range.start ?? 0, count) : blobClient.download()
     );
 
     if (error || !response?.readableStreamBody) {

--- a/apps/backend/src/lib/storage/azure.ts
+++ b/apps/backend/src/lib/storage/azure.ts
@@ -1,7 +1,7 @@
 import { randomUUID, type UUID } from 'node:crypto';
 import fs from 'node:fs/promises';
 import path from 'node:path';
-import { PassThrough, Readable } from 'node:stream';
+import { PassThrough, type Readable } from 'node:stream';
 import {
   BlobServiceClient,
   type ContainerClient,
@@ -27,7 +27,7 @@ import type {
   ReportUploadMetadata,
   Storage,
 } from './types.js';
-import { resolveFileRange } from './types.js';
+import { parseContentRange, resolveFileRange, unsatisfiableRangeResult } from './types.js';
 
 const createClient = (): {
   serviceClient: BlobServiceClient;
@@ -101,12 +101,7 @@ export class AzureBlob implements Storage {
 
       if (resolved.contentLength <= 0) {
         // Unsatisfiable: start past EOF.
-        return {
-          body: Readable.from([]),
-          size: 0,
-          totalSize,
-          contentRange: { start: resolved.start, end: resolved.end, total: totalSize },
-        };
+        return unsatisfiableRangeResult(resolved, totalSize);
       }
 
       const { result: response, error } = await withError(
@@ -143,10 +138,10 @@ export class AzureBlob implements Storage {
       body: response.readableStreamBody as unknown as Readable,
       size: typeof response.contentLength === 'number' ? response.contentLength : undefined,
     };
-    const m = response.contentRange ? /bytes (\d+)-(\d+)\/(\d+)/.exec(response.contentRange) : null;
-    if (m) {
-      result.contentRange = { start: Number(m[1]), end: Number(m[2]), total: Number(m[3]) };
-      result.totalSize = Number(m[3]);
+    const parsed = parseContentRange(response.contentRange);
+    if (parsed) {
+      result.contentRange = parsed;
+      result.totalSize = parsed.total;
     }
     return result;
   }

--- a/apps/backend/src/lib/storage/fs.ts
+++ b/apps/backend/src/lib/storage/fs.ts
@@ -2,7 +2,7 @@ import { randomUUID } from 'node:crypto';
 import { createReadStream, createWriteStream } from 'node:fs';
 import fs from 'node:fs/promises';
 import path from 'node:path';
-import type { PassThrough } from 'node:stream';
+import { PassThrough, Readable } from 'node:stream';
 import { pipeline } from 'node:stream/promises';
 import getFolderSize from 'get-folder-size';
 import { Open } from 'unzipper';
@@ -31,6 +31,7 @@ import type {
   ReportUploadMetadata,
   Storage,
 } from './types.js';
+import { resolveFileRange } from './types.js';
 
 async function createDirectoriesIfMissing() {
   await createDirectory(RESULTS_FOLDER);
@@ -47,18 +48,27 @@ async function readFile(
   const { result: stat, error: statErr } = await withError(fs.stat(fullPath));
   if (statErr || !stat?.isFile()) return null;
   const total = stat.size;
+
   if (range) {
-    const start = Math.max(0, Math.floor(range.start));
-    const end = range.end !== undefined ? Math.min(Math.floor(range.end), total - 1) : total - 1;
-    if (start < total && start <= end) {
+    const resolved = resolveFileRange(total, range);
+    if (resolved.contentLength <= 0) {
+      // Unsatisfiable range (e.g. start past EOF) — empty stream so the caller
+      // can respond 416 Range Not Satisfiable.
       return {
-        body: createReadStream(fullPath, { start, end }),
-        size: end - start + 1,
+        body: Readable.from([]),
+        size: 0,
         totalSize: total,
-        contentRange: { start, end, total },
+        contentRange: { start: resolved.start, end: resolved.end, total },
       };
     }
+    return {
+      body: createReadStream(fullPath, { start: resolved.start, end: resolved.end }),
+      size: resolved.contentLength,
+      totalSize: total,
+      contentRange: { start: resolved.start, end: resolved.end, total },
+    };
   }
+
   return { body: createReadStream(fullPath), size: total, totalSize: total };
 }
 

--- a/apps/backend/src/lib/storage/fs.ts
+++ b/apps/backend/src/lib/storage/fs.ts
@@ -2,7 +2,7 @@ import { randomUUID } from 'node:crypto';
 import { createReadStream, createWriteStream } from 'node:fs';
 import fs from 'node:fs/promises';
 import path from 'node:path';
-import { PassThrough, Readable } from 'node:stream';
+import type { PassThrough } from 'node:stream';
 import { pipeline } from 'node:stream/promises';
 import getFolderSize from 'get-folder-size';
 import { Open } from 'unzipper';
@@ -31,7 +31,7 @@ import type {
   ReportUploadMetadata,
   Storage,
 } from './types.js';
-import { resolveFileRange } from './types.js';
+import { resolveFileRange, unsatisfiableRangeResult } from './types.js';
 
 async function createDirectoriesIfMissing() {
   await createDirectory(RESULTS_FOLDER);
@@ -54,12 +54,7 @@ async function readFile(
     if (resolved.contentLength <= 0) {
       // Unsatisfiable range (e.g. start past EOF) — empty stream so the caller
       // can respond 416 Range Not Satisfiable.
-      return {
-        body: Readable.from([]),
-        size: 0,
-        totalSize: total,
-        contentRange: { start: resolved.start, end: resolved.end, total },
-      };
+      return unsatisfiableRangeResult(resolved, total);
     }
     return {
       body: createReadStream(fullPath, { start: resolved.start, end: resolved.end }),

--- a/apps/backend/src/lib/storage/s3.ts
+++ b/apps/backend/src/lib/storage/s3.ts
@@ -36,6 +36,7 @@ import type {
   ReportUploadMetadata,
   Storage,
 } from './types.js';
+import { parseContentRange } from './types.js';
 
 const createClient = () => {
   const endPoint = env.S3_ENDPOINT;
@@ -177,10 +178,10 @@ export class S3 implements Storage {
       body: response.Body as Readable,
       size: typeof response.ContentLength === 'number' ? response.ContentLength : undefined,
     };
-    const m = response.ContentRange ? /bytes (\d+)-(\d+)\/(\d+)/.exec(response.ContentRange) : null;
-    if (m) {
-      result.contentRange = { start: Number(m[1]), end: Number(m[2]), total: Number(m[3]) };
-      result.totalSize = Number(m[3]);
+    const parsed = parseContentRange(response.ContentRange);
+    if (parsed) {
+      result.contentRange = parsed;
+      result.totalSize = parsed.total;
     }
     return result;
   }

--- a/apps/backend/src/lib/storage/s3.ts
+++ b/apps/backend/src/lib/storage/s3.ts
@@ -147,12 +147,23 @@ export class S3 implements Storage {
       ? targetPath
       : `${REPORTS_BUCKET}/${targetPath}`;
 
+    // Build the Range header. S3 natively supports suffix ranges (bytes=-N) and
+    // open-ended ranges (bytes=X-), as well as closed ranges (bytes=X-Y).
+    let rangeHeader: string | undefined;
+    if (range) {
+      if (range.suffixLength !== undefined) {
+        rangeHeader = `bytes=-${range.suffixLength}`;
+      } else {
+        rangeHeader = `bytes=${range.start ?? 0}-${range.end ?? ''}`;
+      }
+    }
+
     const { result: response, error } = await withError(
       this.client.send(
         new GetObjectCommand({
           Bucket: this.bucket,
           Key: remotePath,
-          Range: range ? `bytes=${range.start}-${range.end ?? ''}` : undefined,
+          Range: rangeHeader,
         })
       )
     );

--- a/apps/backend/src/lib/storage/types.ts
+++ b/apps/backend/src/lib/storage/types.ts
@@ -5,8 +5,59 @@ import type { Pagination } from '../pagination.js';
 export type { ReportPath, ServerDataInfo };
 
 export interface ByteRange {
-  start: number;
+  /** First byte offset to serve (defaults to 0). Mutually exclusive with suffixLength. */
+  start?: number;
+  /** Inclusive end byte offset (defaults to the last byte). */
   end?: number;
+  /** Serve the last N bytes; resolved against the file size by the backend. */
+  suffixLength?: number;
+}
+
+/** Resolve a (possibly partial or suffix) range request against a known file size. */
+export function resolveFileRange(
+  totalSize: number,
+  range?: ByteRange
+): { start: number; end: number; contentLength: number } {
+  let start = range?.start ?? 0;
+  let end = range?.end ?? totalSize - 1;
+
+  if (range?.suffixLength !== undefined) {
+    start = totalSize - range.suffixLength;
+    end = totalSize - 1;
+  }
+
+  start = Math.max(0, start);
+  end = Math.min(end, totalSize - 1);
+
+  return { start, end, contentLength: end - start + 1 };
+}
+
+/**
+ * Parse an HTTP Range header (e.g. "bytes=0-1023", "bytes=512-", "bytes=-256")
+ * into a {@link ByteRange}. The backend resolves open-ended and suffix ranges
+ * against the file size. Returns undefined for a malformed / non-bytes range.
+ */
+export function parseRangeHeader(rangeHeader: string): ByteRange | undefined {
+  const match = rangeHeader.match(/^bytes=(\d*)-(\d*)$/);
+
+  if (!match) return undefined;
+
+  const [, rawStart, rawEnd] = match;
+
+  if (rawStart === '' && rawEnd === '') return undefined;
+
+  if (rawStart === '') {
+    const suffixLength = parseInt(rawEnd, 10);
+    if (suffixLength <= 0) return undefined;
+    return { suffixLength };
+  }
+
+  const start = parseInt(rawStart, 10);
+  if (rawEnd === '') return { start };
+
+  const end = parseInt(rawEnd, 10);
+  if (end < start) return undefined;
+  return { start, end };
 }
 
 export interface ReadFileResult {

--- a/apps/backend/src/lib/storage/types.ts
+++ b/apps/backend/src/lib/storage/types.ts
@@ -1,4 +1,4 @@
-import type { PassThrough, Readable } from 'node:stream';
+import { type PassThrough, Readable } from 'node:stream';
 import type { ReportInfo, ReportPath, ServerDataInfo, UUID } from '@playwright-reports/shared';
 import type { Pagination } from '../pagination.js';
 
@@ -18,12 +18,14 @@ export function resolveFileRange(
   totalSize: number,
   range?: ByteRange
 ): { start: number; end: number; contentLength: number } {
-  let start = range?.start ?? 0;
-  let end = range?.end ?? totalSize - 1;
-
+  let start: number;
+  let end: number;
   if (range?.suffixLength !== undefined) {
     start = totalSize - range.suffixLength;
     end = totalSize - 1;
+  } else {
+    start = range?.start ?? 0;
+    end = range?.end ?? totalSize - 1;
   }
 
   start = Math.max(0, start);
@@ -60,11 +62,33 @@ export function parseRangeHeader(rangeHeader: string): ByteRange | undefined {
   return { start, end };
 }
 
+/** Parse a storage-response Content-Range header ("bytes 0-1023/4096") into bounds. */
+export function parseContentRange(
+  header: string | undefined
+): { start: number; end: number; total: number } | undefined {
+  const m = header ? /bytes (\d+)-(\d+)\/(\d+)/.exec(header) : null;
+  if (!m) return undefined;
+  return { start: Number(m[1]), end: Number(m[2]), total: Number(m[3]) };
+}
+
 export interface ReadFileResult {
   body: Readable;
   size?: number;
   totalSize?: number;
   contentRange?: { start: number; end: number; total: number };
+}
+
+/** Build the empty ReadFileResult a backend returns for an unsatisfiable range (→ 416). */
+export function unsatisfiableRangeResult(
+  resolved: { start: number; end: number },
+  totalSize: number
+): ReadFileResult {
+  return {
+    body: Readable.from([]),
+    size: 0,
+    totalSize,
+    contentRange: { start: resolved.start, end: resolved.end, total: totalSize },
+  };
 }
 
 export interface Storage {

--- a/apps/backend/src/routes/serve.ts
+++ b/apps/backend/src/routes/serve.ts
@@ -15,7 +15,7 @@ import { reportDb } from '../lib/service/db/index.js';
 import { DATA_FOLDER, REPORTS_FOLDER } from '../lib/storage/constants.js';
 import { storage } from '../lib/storage/index.js';
 import { streamToString } from '../lib/storage/streamUtils.js';
-import { parseRangeHeader, type ByteRange } from '../lib/storage/types.js';
+import { type ByteRange, parseRangeHeader } from '../lib/storage/types.js';
 import { extractReportIdFromPath } from '../lib/utils/url-parser.js';
 import { withError } from '../lib/withError.js';
 
@@ -135,11 +135,11 @@ export async function registerServeRoutes(fastify: FastifyInstance) {
 
       const isIndexHtml = contentType === 'text/html' && targetPath.endsWith('index.html');
       // no Range for index.html: it's mutated (LLM button injection) and served whole.
-      const range: ByteRange | undefined = isIndexHtml
-        ? undefined
-        : typeof request.headers.range === 'string'
-          ? parseRangeHeader(request.headers.range.trim())
+      const rangeHeader =
+        !isIndexHtml && typeof request.headers.range === 'string'
+          ? request.headers.range.trim()
           : undefined;
+      const range: ByteRange | undefined = rangeHeader ? parseRangeHeader(rangeHeader) : undefined;
 
       // one indexed point-lookup per served file;
       // add a reportId->prefix memo cache only if serve throughput needs.

--- a/apps/backend/src/routes/serve.ts
+++ b/apps/backend/src/routes/serve.ts
@@ -15,7 +15,7 @@ import { reportDb } from '../lib/service/db/index.js';
 import { DATA_FOLDER, REPORTS_FOLDER } from '../lib/storage/constants.js';
 import { storage } from '../lib/storage/index.js';
 import { streamToString } from '../lib/storage/streamUtils.js';
-import type { ByteRange } from '../lib/storage/types.js';
+import { parseRangeHeader, type ByteRange } from '../lib/storage/types.js';
 import { extractReportIdFromPath } from '../lib/utils/url-parser.js';
 import { withError } from '../lib/withError.js';
 
@@ -89,16 +89,6 @@ function sendServeDenied(request: FastifyRequest, reply: FastifyReply): FastifyR
   return reply.code(403).send({ error: 'Forbidden' });
 }
 
-function parseRange(header: string | string[] | undefined): ByteRange | undefined {
-  if (typeof header !== 'string') return undefined;
-  const m = /^bytes=(\d+)-(\d*)$/.exec(header.trim());
-  if (!m) return undefined;
-  const start = Number(m[1]);
-  const end = m[2] ? Number(m[2]) : undefined;
-  if (end !== undefined && end < start) return undefined;
-  return { start, end };
-}
-
 export async function registerServeRoutes(fastify: FastifyInstance) {
   fastify.get('/api/serve/*', async (request, reply) => {
     try {
@@ -145,7 +135,11 @@ export async function registerServeRoutes(fastify: FastifyInstance) {
 
       const isIndexHtml = contentType === 'text/html' && targetPath.endsWith('index.html');
       // no Range for index.html: it's mutated (LLM button injection) and served whole.
-      const range = isIndexHtml ? undefined : parseRange(request.headers.range);
+      const range: ByteRange | undefined = isIndexHtml
+        ? undefined
+        : typeof request.headers.range === 'string'
+          ? parseRangeHeader(request.headers.range.trim())
+          : undefined;
 
       // one indexed point-lookup per served file;
       // add a reportId->prefix memo cache only if serve throughput needs.
@@ -182,11 +176,22 @@ export async function registerServeRoutes(fastify: FastifyInstance) {
       if (!isIndexHtml) {
         headers['Accept-Ranges'] = 'bytes';
         if (result.size !== undefined) headers['Content-Length'] = String(result.size);
+
         if (result.contentRange) {
           const { start, end, total } = result.contentRange;
+
+          // Unsatisfiable range (start past EOF) — 416 Range Not Satisfiable.
+          if (result.size !== undefined && result.size <= 0) {
+            return reply
+              .code(416)
+              .headers({ ...headers, 'Content-Range': `bytes */${total}` })
+              .send();
+          }
+
           headers['Content-Range'] = `bytes ${start}-${end}/${total}`;
           return reply.code(206).headers(headers).send(result.body);
         }
+
         return reply.code(200).headers(headers).send(result.body);
       }
 


### PR DESCRIPTION
E2e tests occasionally produce video recordings exceeding 100MB. Previously, the server read the entire file into memory before serving it to the browser.
This PR adds Content-Range HTTP header support for partial file streaming, allowing the browser's video player to stream video in chunks and begin playback immediately. It also enables seeking, with the server streaming only from the requested byte offset onward.