### PR TITLE
chore: bump server version to 6.1.1 and document environment metadata

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@playwright-reports/backend",
-	"version": "6.1.0",
+	"version": "6.1.1",
 	"description": "Playwright Reports Server Backend",
 	"type": "module",
 	"files": [

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@playwright-reports/frontend",
-  "version": "6.1.0",
+  "version": "6.1.1",
   "description": "Playwright Reports Server Frontend",
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "playwright-reports-server",
-  "version": "6.1.0",
+  "version": "6.1.1",
   "description": "Playwright Reports Server: Can be used to accept blobs, merge them, store and view Playwright reports",
   "type": "module",
   "packageManager": "pnpm@11.17.0",

--- a/packages/reporter/README.md
+++ b/packages/reporter/README.md
@@ -33,6 +33,7 @@ In your `playwright.config.ts` or `playwright.config.js`:
         // Any custom metadata to attach to this blob (strings)
         resultDetails: {
           branch: process.env.CI_COMMIT_BRANCH,
+          environment: process.env.DEPLOY_ENV, // qa, staging, prod - shown in the Env column
           foo: 'bar',
           bar: 'baz'
         },
@@ -44,6 +45,8 @@ In your `playwright.config.ts` or `playwright.config.js`:
 ```
 
 Then run your tests, if you see `[ReporterPlaywrightReportsServer] 🎭 HTML Report is available at: ...` - your blob results were successfully sent to server!
+
+Pass `environment` in `resultDetails` to label the deployment target (`qa`, `staging`, `prod`, …). The server shows it in a dedicated **Env** column on the reports list and you can filter with `?tags=environment:qa`.
 
 ## Shards
 

--- a/website/Uploading-Reports.md
+++ b/website/Uploading-Reports.md
@@ -49,6 +49,8 @@ export default defineConfig({
 
 With `triggerReportGeneration: true`, every `resultDetails` field is copied onto the generated report as well, so `?tags=branch:main` filters reports and results alike, and the fields show up on the report detail page. The only exceptions are `triggerReportGeneration` itself and the `shardCurrent` / `shardTotal` pair, which describe a single blob rather than the merged report.
 
+`environment` is the conventional field for the deployment target (`qa`, `staging`, `prod`, …). Pass it in `resultDetails` (or as `--meta environment=qa` on a CLI upload) and the reports list shows it in a dedicated **Env** column; filter with `?tags=environment:qa` like any other tag. Reports uploaded without it show a muted *no env* placeholder.
+
 Bumping defaults when CI is slow or blobs are large: `requestTimeout` (60s) and `blobUploadTimeout` (10min). Setting `enabled: false` disables the reporter for local runs you don't want cluttering the dashboard.
 
 Full reporter docs: [`packages/reporter/README.md`](https://github.com/CyborgTests/playwright-reports-server/blob/main/packages/reporter/README.md).
@@ -91,6 +93,7 @@ npx --package=@cyborgtests/reporter playwright-reporter-cli upload ./playwright-
   --title "Nightly Run 2026-05-29" \
   --tags ci,nightly \
   --meta branch=main \
+  --meta environment=qa \
   --meta build=12345
 ```
 


### PR DESCRIPTION
Document the environment resultDetails field for the new Env column on the reports list.