### PR TITLE
fix(azure): sign copy source with read SAS when committing report

### DIFF
--- a/apps/backend/src/lib/storage/azure.test.ts
+++ b/apps/backend/src/lib/storage/azure.test.ts
@@ -1,0 +1,66 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+// Azure's env is validated at import time; provide the minimum a client needs.
+// The key only has to be valid base64 - SAS signing is a local HMAC, so these
+// fake credentials let us exercise commitPrefix without any network or emulator.
+process.env.DATA_STORAGE = 'azure';
+process.env.AZURE_ACCOUNT_NAME ??= 'devstoreaccount1';
+process.env.AZURE_ACCOUNT_KEY ??= Buffer.from('unit-test-key').toString('base64');
+process.env.AZURE_CONTAINER ??= 'test-container';
+
+describe('AzureBlob.commitPrefix', () => {
+  it('copies each blob from the tmp prefix to the final prefix using a signed read SAS source', async () => {
+    const { AzureBlob } = await import('./azure.js');
+
+    // biome-ignore lint/suspicious/noExplicitAny: reach into private members to stub the network.
+    const azure = AzureBlob.getInstance() as any;
+    const container = azure.container;
+
+    const srcPrefix = 'reports/report-1.tmp';
+    const dstPrefix = 'reports/report-1';
+    const tmpBlobs = [`${srcPrefix}/index.html`, `${srcPrefix}/data/report.json`];
+
+    // Serve the tmp blobs from listBlobsFlat; every other prefix (e.g. the
+    // clearPrefix sweep of the destination) lists nothing.
+    container.listBlobsFlat = ({ prefix }: { prefix: string }) =>
+      (async function* () {
+        if (prefix.startsWith(srcPrefix)) {
+          for (const name of tmpBlobs) yield { name };
+        }
+      })();
+
+    // Wrap the real getBlobClient so generateSasUrl still runs for real, but the
+    // network calls (copy + delete) are captured instead of hitting Azure.
+    const copies: { dst: string; src: string }[] = [];
+    const realGetBlobClient = container.getBlobClient.bind(container);
+    container.getBlobClient = (key: string) => {
+      const client = realGetBlobClient(key);
+      client.syncCopyFromURL = async (url: string) => {
+        copies.push({ dst: key, src: url });
+        return {};
+      };
+      client.deleteIfExists = async () => ({});
+      return client;
+    };
+
+    await azure.commitPrefix(srcPrefix, dstPrefix);
+
+    // One copy per tmp blob, remapped from the tmp prefix to the final prefix.
+    assert.deepEqual(copies.map((c) => c.dst).sort(), [
+      'reports/report-1/data/report.json',
+      'reports/report-1/index.html',
+    ]);
+
+    // Regression guard: the copy *source* must be a signed read SAS URL, not the
+    // bare blob URL. Azure authenticates the copy source independently of the
+    // request's shared-key signature, so a bare URL fails against a private
+    // container. A bare URL carries no `sig`; the fix adds one.
+    for (const { src } of copies) {
+      const url = new URL(src);
+      assert.ok(url.searchParams.has('sig'), `copy source is not SAS-signed: ${src}`);
+      assert.ok(url.searchParams.has('se'), 'SAS is missing an expiry');
+      assert.equal(url.searchParams.get('sp'), 'r', 'SAS must grant read-only access');
+    }
+  });
+});

--- a/apps/backend/src/lib/storage/azure.ts
+++ b/apps/backend/src/lib/storage/azure.ts
@@ -3,6 +3,7 @@ import fs from 'node:fs/promises';
 import path from 'node:path';
 import { PassThrough, type Readable } from 'node:stream';
 import {
+  BlobSASPermissions,
   BlobServiceClient,
   type ContainerClient,
   StorageSharedKeyCredential,
@@ -460,7 +461,14 @@ export class AzureBlob implements Storage {
     const srcBlobs = await this.listBlobsUnderPrefix(srcPrefix);
     await processWithConcurrency(srcBlobs, this.batchSize, async (srcKey) => {
       const dstKey = `${dstPrefix}${srcKey.slice(srcPrefix.length)}`;
-      const srcUrl = this.container.getBlobClient(srcKey).url;
+      // Azure authenticates the copy *source* independently of the request's
+      // shared-key signature, so a bare blob URL to a private container has no
+      // credentials and the copy fails. Sign the source with a short-lived read
+      // SAS so `syncCopyFromURL` can read it.
+      const srcUrl = await this.container.getBlobClient(srcKey).generateSasUrl({
+        permissions: BlobSASPermissions.parse('r'),
+        expiresOn: new Date(Date.now() + 10 * 60 * 1000),
+      });
       await this.container.getBlobClient(dstKey).syncCopyFromURL(srcUrl);
     });
     await this.clearPrefix(srcPrefix);


### PR DESCRIPTION
Azure authenticates the copy *source* of a Copy Blob From URL operation independently of the request's shared-key signature. commitPrefix passed a bare, unsigned blob URL to syncCopyFromURL, so against a private container the copy-source read failed with "Server failed to authenticate the request ... www-authenticate header", making every report commit fail on Azure (uploads/downloads were unaffected since those are shared-key signed).

Generate a short-lived read-only SAS for the source blob before the copy, mirroring how the S3 backend names its source inside a signed request.